### PR TITLE
Gracefully handle socket errors during SSDP discovery.

### DIFF
--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -221,20 +221,6 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
         except OSError:
             pass
 
-    if not sockets:
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-
-            # Set the time-to-live for messages for local network
-            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 1)
-            sock.bind(('0.0.0.0', 0))
-
-            sockets.append(sock)
-        except OSError:
-            logging.getLogger(__name__).exception(
-                "Socket error while trying to discover SSDP devices")
-            return []
-
     entries = []
     for sock in [s for s in sockets]:
         try:

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -185,7 +185,7 @@ class UPNPEntry(object):
             self.values.get('st', ''), self.values.get('location', ''))
 
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,too-many-locals
 def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
     """
     Sends a message over the network to discover upnp devices.
@@ -236,7 +236,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
             return []
 
     entries = []
-    for sock in sockets:
+    for sock in [s for s in sockets]:
         try:
             sock.sendto(ssdp_request, SSDP_TARGET)
             sock.setblocking(False)
@@ -270,12 +270,13 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
 
                     if max_entries and len(entries) == max_entries:
                         raise StopIteration
+
     except StopIteration:
         pass
 
     finally:
-        for sock in sockets:
-            sock.close()
+        for s in sockets:
+            s.close()
 
     return entries
 

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -236,12 +236,16 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
             return []
 
     entries = []
-    try:
-        for sock in sockets:
+    for sock in sockets:
+        try:
             sock.sendto(ssdp_request, SSDP_TARGET)
-            sock.setblocking(0)
+            sock.setblocking(False)
+        except OSError:
+            sockets.remove(sock)
+            sock.close()
 
-        while True:
+    try:
+        while sockets:
             time_diff = stop_wait - datetime.now()
             seconds_left = time_diff.total_seconds()
             if seconds_left <= 0:
@@ -250,7 +254,14 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
             ready = select.select(sockets, [], [], seconds_left)[0]
 
             for sock in ready:
-                response = sock.recv(1024).decode("utf-8")
+                try:
+                    response = sock.recv(1024).decode("utf-8")
+                except OSError:
+                    logging.getLogger(__name__).exception(
+                        "Socket error while discovering SSDP devices")
+                    sockets.remove(sock)
+                    sock.close()
+                    continue
 
                 entry = UPNPEntry.from_response(response)
 
@@ -259,11 +270,6 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
 
                     if max_entries and len(entries) == max_entries:
                         raise StopIteration
-
-    except socket.error:
-        logging.getLogger(__name__).exception(
-            "Socket error while discovering SSDP devices")
-
     except StopIteration:
         pass
 

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -218,7 +218,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
             sock.bind((addr, 0))
 
             sockets.append(sock)
-        except OSError:
+        except socket.error:
             pass
 
     entries = []
@@ -226,7 +226,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
         try:
             sock.sendto(ssdp_request, SSDP_TARGET)
             sock.setblocking(False)
-        except OSError:
+        except socket.error:
             sockets.remove(sock)
             sock.close()
 
@@ -242,7 +242,7 @@ def scan(st=None, timeout=DISCOVER_TIMEOUT, max_entries=None):
             for sock in ready:
                 try:
                     response = sock.recv(1024).decode("utf-8")
-                except OSError:
+                except socket.error:
                     logging.getLogger(__name__).exception(
                         "Socket error while discovering SSDP devices")
                     sockets.remove(sock)


### PR DESCRIPTION
Now that we use multiple sockets during discovery, we should not abort discovery whenever we hit a socket error. (#25)