### PR TITLE
Discover Home Assistant instances

### DIFF
--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -11,3 +11,4 @@ SONOS = "sonos"
 PANASONIC_VIERA = "panasonic_viera"
 SABNZBD = 'sabnzbd'
 KODI = 'kodi'
+HOME_ASSISTANT = "home_assistant"

--- a/netdisco/discoverables/home_assistant.py
+++ b/netdisco/discoverables/home_assistant.py
@@ -1,0 +1,20 @@
+"""Discover Home Assistant servers."""
+from . import MDNSDiscoverable
+
+
+# pylint: disable=too-few-public-methods
+class Discoverable(MDNSDiscoverable):
+    """Add support for discovering Home Assistant instances."""
+
+    def __init__(self, nd):
+        super(Discoverable, self).__init__(nd, '_home-assistant._tcp.local.')
+
+    def info_from_entry(self, entry):
+        """Returns most important info from mDNS entries."""
+        return (entry.properties.get(b'base_url').decode('utf-8'),
+                entry.properties.get(b'version').decode('utf-8'),
+                entry.properties.get(b'requires_api_password'))
+
+    def get_info(self):
+        """Get details from Home Assistant instances."""
+        return [self.info_from_entry(entry) for entry in self.get_entries()]


### PR DESCRIPTION
Thanks to the [zeroconf component](https://home-assistant.io/components/zeroconf/) Home Assistant is discoverable.

```bash
home_assistant [('http://10.100.0.197:8123', '0.24.0.dev0', True)]
```