### PR TITLE
fix ctrl url discovery

### DIFF
--- a/netdisco/discoverables/yamaha.py
+++ b/netdisco/discoverables/yamaha.py
@@ -1,5 +1,4 @@
 """Discover Yamaha Receivers."""
-from netdisco.util import urlparse
 from . import SSDPDiscoverable
 
 
@@ -9,15 +8,13 @@ class Discoverable(SSDPDiscoverable):
     def info_from_entry(self, entry):
         """Return the most important info from a uPnP entry."""
         descurl = entry.values['location']
-        url = urlparse(entry.values['location'])
         yam = entry.description['X_device']
-        ctrlurl = "%s://%s%s" % (
-            url.scheme,
-            url.netloc,
-            yam['X_serviceList']['X_service']['X_controlURL'])
+        # do a slice of the second element so we don't have double /
+        ctrlurl = (yam['X_URLBase'] +
+                   yam['X_serviceList']['X_service']['X_controlURL'][1:])
         device = entry.description['device']
 
-        return (device['friendlyName'], ctrlurl, descurl)
+        return (device['friendlyName'], device['modelName'], ctrlurl, descurl)
 
     def get_entries(self):
         """Get all the Yamaha uPnP entries."""


### PR DESCRIPTION
It turns out that on yamaha receivers the discovered port (typically
port 8080) for the desc.xml *is not* actually active for the control
url, which is typically sitting on port 80 (and is expressed with the
yamaha:X_URLBase field).

This is a bit more strict about using that field to build up the
control url.

It also returns model_name which the rxv code asks for. This allows
the netdisco discovery to be a full replacement for the ssdp code in
rxv at least as far as home-assistant is concerned, and should enable
yamaha via the discovery component.