### PR TITLE
final fix for yamaha discovery

### DIFF
--- a/netdisco/discoverables/yamaha.py
+++ b/netdisco/discoverables/yamaha.py
@@ -7,11 +7,12 @@ class Discoverable(SSDPDiscoverable):
 
     def info_from_entry(self, entry):
         """Return the most important info from a uPnP entry."""
-        descurl = entry.values['location']
         yam = entry.description['X_device']
         # do a slice of the second element so we don't have double /
         ctrlurl = (yam['X_URLBase'] +
                    yam['X_serviceList']['X_service']['X_controlURL'][1:])
+        descurl = (yam['X_URLBase'] +
+                   yam['X_serviceList']['X_service']['X_unitDescURL'][1:])
         device = entry.description['device']
 
         return (device['friendlyName'], device['modelName'], ctrlurl, descurl)


### PR DESCRIPTION
When discovering zones for the yamaha receiver, we are actually
probing the xml of the yamaha specific desc.xml, which provides all
the function details of the system (it's kind of soap-esque dump). The
generic desc.xml isn't good enough, and if we use that we don't end up
with any receivers discovered because no zones are found.