### PR TITLE
Disable Samsung AC scanning

### DIFF
--- a/netdisco/__main__.py
+++ b/netdisco/__main__.py
@@ -27,5 +27,6 @@ def main():
 
     netdisco.stop()
 
+
 if __name__ == '__main__':
     main()

--- a/netdisco/daikin.py
+++ b/netdisco/daikin.py
@@ -100,5 +100,6 @@ def main():
     daikin.update()
     pprint(daikin.entries)
 
+
 if __name__ == "__main__":
     main()

--- a/netdisco/discoverables/samsungac.py
+++ b/netdisco/discoverables/samsungac.py
@@ -11,4 +11,5 @@ class Discoverable(BaseDiscoverable):
 
     def get_entries(self):
         """Get all the Samsung Smart AC details."""
-        return self._netdis.samsungac.entries
+        return []
+        # return self._netdis.samsungac.entries

--- a/netdisco/discovery.py
+++ b/netdisco/discovery.py
@@ -10,7 +10,7 @@ from .gdm import GDM
 from .lms import LMS
 from .tellstick import Tellstick
 from .daikin import Daikin
-from .samsungac import SamsungAC
+# from .samsungac import SamsungAC
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class NetworkDiscovery(object):
         self.lms = LMS()
         self.tellstick = Tellstick()
         self.daikin = Daikin()
-        self.samsungac = SamsungAC()
+        # self.samsungac = SamsungAC()
         self.discoverables = {}
 
         self._load_device_support()
@@ -59,7 +59,7 @@ class NetworkDiscovery(object):
         self.lms.scan()
         self.tellstick.scan()
         self.daikin.scan()
-        self.samsungac.scan()
+        # self.samsungac.scan()
 
     def stop(self):
         """Turn discovery off."""

--- a/netdisco/gdm.py
+++ b/netdisco/gdm.py
@@ -106,5 +106,6 @@ def main():
     gdm.update()
     pprint(gdm.entries)
 
+
 if __name__ == "__main__":
     main()

--- a/netdisco/lms.py
+++ b/netdisco/lms.py
@@ -66,5 +66,6 @@ def main():
     lms.update()
     pprint(lms.entries)
 
+
 if __name__ == "__main__":
     main()

--- a/netdisco/samsungac.py
+++ b/netdisco/samsungac.py
@@ -108,5 +108,6 @@ def main():
     samsungac.update()
     pprint(samsungac.entries)
 
+
 if __name__ == "__main__":
     main()

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -274,5 +274,6 @@ def main():
     pprint("Scanning SSDP..")
     pprint(scan())
 
+
 if __name__ == "__main__":
     main()

--- a/netdisco/tellstick.py
+++ b/netdisco/tellstick.py
@@ -64,5 +64,6 @@ def main():
     tellstick.update()
     pprint(tellstick.entries)
 
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The Samsung AC discovery runs on port 1900 which is occupied by a lot of systems for upnp. Caused anyone with a synology to run into issues.

#66 might be a fix but we will need @sfam to confirm that it still works for him and will need @jaharkes to confirm that it still works on synology.