### PR TITLE
Discover Samsung Smart TV

### DIFF
--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -15,3 +15,4 @@ HOME_ASSISTANT = "home_assistant"
 MYSTROM = 'mystrom'
 HASS_IOS = "hass_ios"
 BOSE_SOUNDTOUCH = 'bose_soundtouch'
+SAMSUNG_TV = "samsung_tv"

--- a/netdisco/discoverables/samsung_tv.py
+++ b/netdisco/discoverables/samsung_tv.py
@@ -1,0 +1,20 @@
+"""Discover Samsung Smart TV services."""
+from urllib.parse import urlparse
+
+from . import SSDPDiscoverable
+
+class Discoverable(SSDPDiscoverable):
+    """Add support for discovering Samsung Smart TV services."""
+
+    def get_entries(self):
+        """Get all the Samsung RemoteControlReceiver entries."""
+        return self.find_by_device_description({
+            "deviceType": "urn:samsung.com:device:RemoteControlReceiver:1"
+        })
+
+    def info_from_entry(self, entry):
+        """Get most important info, by default the description location."""
+        host = urlparse(entry.values['location']).hostname
+        name = entry.description['device']['friendlyName']
+        model = entry.description['device']['modelName']
+        return name, model, host

--- a/netdisco/discoverables/samsung_tv.py
+++ b/netdisco/discoverables/samsung_tv.py
@@ -3,6 +3,9 @@ from urllib.parse import urlparse
 
 from . import SSDPDiscoverable
 
+# For some models, Samsung forces a [TV] prefix to the user-specified name.
+FORCED_NAME_PREFIX = '[TV]'
+
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering Samsung Smart TV services."""
 
@@ -14,7 +17,15 @@ class Discoverable(SSDPDiscoverable):
 
     def info_from_entry(self, entry):
         """Get most important info, by default the description location."""
-        host = urlparse(entry.values['location']).hostname
+
         name = entry.description['device']['friendlyName']
+        # Strip the forced prefix, if present
+        if name.startswith(FORCED_NAME_PREFIX):
+            name = name[len(FORCED_NAME_PREFIX):]
+
         model = entry.description['device']['modelName']
+
+        # Extract the IP address from the location; it is not given in the XML.
+        host = urlparse(entry.values['location']).hostname
+
         return name, model, host

--- a/netdisco/discoverables/samsung_tv.py
+++ b/netdisco/discoverables/samsung_tv.py
@@ -1,10 +1,17 @@
 """Discover Samsung Smart TV services."""
-from urllib.parse import urlparse
+
+try:
+    # python 3
+    from urllib.parse import urlparse
+except ImportError:
+    # python 2
+    from urlparse import urlparse
 
 from . import SSDPDiscoverable
 
 # For some models, Samsung forces a [TV] prefix to the user-specified name.
 FORCED_NAME_PREFIX = '[TV]'
+
 
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering Samsung Smart TV services."""

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -135,6 +135,10 @@ class UPNPEntry(object):
         if url not in UPNPEntry.DESCRIPTION_CACHE:
             try:
                 xml = requests.get(url).text
+                if not xml:
+                    # Samsung Smart TV sometimes returns an empty document the
+                    # first time. Retry once.
+                    xml = requests.get(url).text
 
                 tree = ElementTree.fromstring(xml)
 


### PR DESCRIPTION
Add support for discovering Samsung Smart TV which are able to be controlled by the Samsung Remote Control protocol.

Ad-hoc tested on two models from series D and E.