### PR TITLE
Fix empty lists for Kodi and SABnzbd

### DIFF
--- a/netdisco/discoverables/__init__.py
+++ b/netdisco/discoverables/__init__.py
@@ -72,7 +72,7 @@ class MDNSDiscoverable(BaseDiscoverable):
 
     def is_discovered(self):
         """Return True if any device has been discovered."""
-        return len(self.services) > 0
+        return len(self.get_entries()) > 0
 
     # pylint: disable=unused-argument
     def remove_service(self, zconf, typ, name):
@@ -97,6 +97,11 @@ class MDNSDiscoverable(BaseDiscoverable):
     def info_from_entry(self, entry):
         """Return most important info from mDNS entries."""
         return (self.ip_from_host(entry.server), entry.port)
+
+    def find_by_device_name(self, name):
+        """Find entries based on the beginning of their entry names."""
+        return [entry for entry in self.services.values()
+                if entry.name.startswith(name)]
 
     def ip_from_host(self, host):
         """Attempt to return the ip address from an mDNS host.

--- a/netdisco/discoverables/kodi.py
+++ b/netdisco/discoverables/kodi.py
@@ -14,7 +14,5 @@ class Discoverable(MDNSDiscoverable):
         """Return most important info from mDNS entries."""
         return (self.ip_from_host(entry.server), entry.port)
 
-    def get_info(self):
-        """Get all the Kodi details."""
-        return [self.info_from_entry(entry) for entry in self.get_entries()
-                if entry.name.startswith('Kodi ')]
+    def get_entries(self):
+        return self.find_by_device_name('Kodi ')

--- a/netdisco/discoverables/sabnzbd.py
+++ b/netdisco/discoverables/sabnzbd.py
@@ -15,7 +15,5 @@ class Discoverable(MDNSDiscoverable):
         return (self.ip_from_host(entry.server), entry.port,
                 entry.properties.get('path', '/sabnzbd/'))
 
-    def get_info(self):
-        """Get details of SABnzbd."""
-        return [self.info_from_entry(entry) for entry in self.get_entries()
-                if entry.name.startswith('SABnzbd on')]
+    def get_entries(self):
+        return self.find_by_device_name('SABnzbd on')


### PR DESCRIPTION
Kodi and SABnzbd returned is_discovered() as true even if there are no such devices present, as long as an mDNS '_http._tcp.local.' entity is present on the network.