### PR TITLE
Fixed discovery for Yamaha RX-V481 Receiver

### DIFF
--- a/netdisco/discoverables/yamaha.py
+++ b/netdisco/discoverables/yamaha.py
@@ -8,11 +8,14 @@ class Discoverable(SSDPDiscoverable):
     def info_from_entry(self, entry):
         """Return the most important info from a uPnP entry."""
         yam = entry.description['X_device']
+        services = yam['X_serviceList']['X_service']
+        if isinstance(services, list):
+            service = services[0]
+        else:
+            service = services
         # do a slice of the second element so we don't have double /
-        ctrlurl = (yam['X_URLBase'] +
-                   yam['X_serviceList']['X_service']['X_controlURL'][1:])
-        descurl = (yam['X_URLBase'] +
-                   yam['X_serviceList']['X_service']['X_unitDescURL'][1:])
+        ctrlurl = (yam['X_URLBase'] + service['X_controlURL'][1:])
+        descurl = (yam['X_URLBase'] + service['X_unitDescURL'][1:])
         device = entry.description['device']
 
         return (device['friendlyName'], device['modelName'], ctrlurl, descurl)


### PR DESCRIPTION
My new Yamaha Receiver was causing discovery to error with:
File "/usr/local/lib/python3.4/dist-packages/netdisco/discoverables/yamaha.py", line 13, in info_from_entry
  yam['X_serviceList']['X_service']['X_controlURL'][1:])
TypeError: list indices must be integers, not str

The UPnP entry for my receiver is returning 2 X_service elements under X_serviceList causing yam['X_serviceList']['X_service'] to return a list of service elements instead of a dict representing a single service element.  I fixed the error by adding a type-check and returning the first element if yam['X_serviceList']['X_service'] returns a list.