### PR TITLE
Standardize entry dict

### DIFF
--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -16,3 +16,9 @@ MYSTROM = 'mystrom'
 HASS_IOS = "hass_ios"
 BOSE_SOUNDTOUCH = 'bose_soundtouch'
 SAMSUNG_TV = "samsung_tv"
+
+ATTR_HOST = 'host'
+ATTR_PORT = 'port'
+ATTR_HOSTNAME = 'hostname'
+ATTR_DEVICE_TYPE = 'device_type'
+ATTR_PROPERTIES = 'properties'

--- a/netdisco/discoverables/homekit.py
+++ b/netdisco/discoverables/homekit.py
@@ -1,5 +1,6 @@
 """Discover myStrom devices."""
 from . import MDNSDiscoverable
+from ..const import ATTR_HOST
 
 
 # pylint: disable=too-few-public-methods
@@ -13,7 +14,7 @@ class Discoverable(MDNSDiscoverable):
         """Return the most important info from mDNS entries."""
         info = {key.decode('utf-8'): value.decode('utf-8')
                 for key, value in entry.properties.items()}
-        info['host'] = 'http://{}'.format(self.ip_from_host(entry.server))
+        info[ATTR_HOST] = 'http://{}'.format(self.ip_from_host(entry.server))
         return info
 
     def get_info(self):

--- a/netdisco/discoverables/yeelight.py
+++ b/netdisco/discoverables/yeelight.py
@@ -1,6 +1,8 @@
 """Discover Yeelight bulbs, based on Kodi discoverable."""
 import logging
 from . import MDNSDiscoverable
+from ..const import (
+    ATTR_HOST, ATTR_PORT, ATTR_HOSTNAME, ATTR_DEVICE_TYPE, ATTR_PROPERTIES)
 
 
 # pylint: disable=too-few-public-methods
@@ -22,11 +24,13 @@ class Discoverable(MDNSDiscoverable):
         else:
             logging.warning("Unknown miio device found: %s", entry)
 
-        return {"host": self.ip_from_host(entry.server),
-                "port": entry.port,
-                "hostname": entry.server,
-                "device_type": device_type,
-                "properties": entry.properties}
+        return {
+            ATTR_HOST: self.ip_from_host(entry.server),
+            ATTR_PORT: entry.port,
+            ATTR_HOSTNAME: entry.server,
+            ATTR_DEVICE_TYPE: device_type,
+            ATTR_PROPERTIES: entry.properties,
+        }
 
     def get_entries(self):
         return self.find_by_device_name('yeelink-light-')

--- a/netdisco/lms.py
+++ b/netdisco/lms.py
@@ -2,6 +2,8 @@
 import socket
 import threading
 
+from .const import ATTR_HOST, ATTR_PORT
+
 DISCOVERY_PORT = 3483
 DEFAULT_DISCOVERY_TIMEOUT = 5
 
@@ -53,8 +55,10 @@ class LMS(object):
                         if data.startswith(b'JSON', 1):
                             length = data[5:6][0]
                             port = int(data[0-length:])
-                        entries.append({'port': port,
-                                        'server': server[0]})
+                        entries.append({
+                            ATTR_HOST: server[0],
+                            ATTR_PORT: port,
+                        })
                 except socket.timeout:
                     break
         finally:


### PR DESCRIPTION
For the upcoming netdisco 1.0, we want to move the entry info objects to be all dictionaries. This PR will update all current protocols that return a dict to use standardized keys.