### PR TITLE
Add openhome devices as discoverable

### DIFF
--- a/netdisco/discoverables/openhome.py
+++ b/netdisco/discoverables/openhome.py
@@ -8,7 +8,8 @@ class Discoverable(SSDPDiscoverable):
 
     def info_from_entry(self, entry):
         """Return the most important info from a uPnP entry."""
-        return entry.description['device']['friendlyName'], entry.values['location']
+        return (entry.description['device']['friendlyName'], 
+                entry.values['location'])
 
     def get_entries(self):
         """Get all the Openhome compliant device uPnP entries."""

--- a/netdisco/discoverables/openhome.py
+++ b/netdisco/discoverables/openhome.py
@@ -8,7 +8,7 @@ class Discoverable(SSDPDiscoverable):
 
     def info_from_entry(self, entry):
         """Return the most important info from a uPnP entry."""
-        return (entry.description['device']['friendlyName'], 
+        return (entry.description['device']['friendlyName'],
                 entry.values['location'])
 
     def get_entries(self):

--- a/netdisco/discoverables/openhome.py
+++ b/netdisco/discoverables/openhome.py
@@ -1,0 +1,15 @@
+"""Discover Openhome devices."""
+from . import SSDPDiscoverable
+
+
+# pylint: disable=too-few-public-methods
+class Discoverable(SSDPDiscoverable):
+    """Add support for discovering Openhome compliant devices."""
+
+    def info_from_entry(self, entry):
+        """Return the most important info from a uPnP entry."""
+        return entry.description['device']['friendlyName'], entry.values['location']
+
+    def get_entries(self):
+        """Get all the Openhome compliant device uPnP entries."""
+        return self.find_by_st("urn:av-openhome-org:service:Product:2")


### PR DESCRIPTION
This PR adds support for discovering Openhome compliant devices (http://openhome.org/) such as Linn Ds. 