### PR TITLE
Check that ST exists for UPnP device in frontier silicon

### DIFF
--- a/netdisco/discoverables/frontier_silicon.py
+++ b/netdisco/discoverables/frontier_silicon.py
@@ -8,5 +8,5 @@ class Discoverable(SSDPDiscoverable):
     def get_entries(self):
         """Get all the frontier silicon uPnP entries."""
         return [entry for entry in self.netdis.ssdp.all()
-                if 'fsapi' in entry.st and
+                if entry.st and 'fsapi' in entry.st and
                 'urn:schemas-frontier-silicon-com' in entry.st]


### PR DESCRIPTION
My Canon printer does not broadcast ST so netdisco gives in exception in frontier_silicon.py for me:
```
$ python3 -m netdisco
Discovered devices:
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python3/3.5.1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/postlund/git/netdisco/netdisco/__main__.py", line 32, in <module>
    main()
  File "/Users/postlund/git/netdisco/netdisco/__main__.py", line 22, in main
    for dev in netdisco.discover():
  File "/Users/postlund/git/netdisco/netdisco/discovery.py", line 96, in discover
    return [dis for dis, checker in self.discoverables.items()
  File "/Users/postlund/git/netdisco/netdisco/discovery.py", line 97, in <listcomp>
    if checker.is_discovered()]
  File "/Users/postlund/git/netdisco/netdisco/discoverables/__init__.py", line 10, in is_discovered
    return len(self.get_entries()) > 0
  File "/Users/postlund/git/netdisco/netdisco/discoverables/frontier_silicon.py", line 10, in get_entries
    return [entry for entry in self.netdis.ssdp.all()
  File "/Users/postlund/git/netdisco/netdisco/discoverables/frontier_silicon.py", line 11, in <listcomp>
    if 'fsapi' in entry.st and
TypeError: argument of type 'NoneType' is not iterable
```

This PR fixes the crash for me.