### PR TITLE
Add Apple TV support

### DIFF
--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -17,6 +17,7 @@ HASS_IOS = "hass_ios"
 BOSE_SOUNDTOUCH = 'bose_soundtouch'
 SAMSUNG_TV = "samsung_tv"
 FRONTIER_SILICON = "frontier_silicon"
+APPLE_TV = "apple_tv"
 
 ATTR_HOST = 'host'
 ATTR_PORT = 'port'

--- a/netdisco/discoverables/apple_tv.py
+++ b/netdisco/discoverables/apple_tv.py
@@ -1,0 +1,23 @@
+"""Discover Apple TV media players."""
+from . import MDNSDiscoverable
+
+
+# pylint: disable=too-few-public-methods
+class Discoverable(MDNSDiscoverable):
+    """Add support for Apple TV devices."""
+
+    def __init__(self, nd):
+        super(Discoverable, self).__init__(nd, '_appletv-v2._tcp.local.')
+
+    def info_from_entry(self, entry):
+        """Returns most important info from mDNS entries."""
+        props = entry.properties
+        info = {
+            'name': props.get(b'Name').decode('utf-8').replace('\xa0', ' '),
+            'hsgid': props.get(b'hG').decode('utf-8')
+            }
+        return info
+
+    def get_info(self):
+        """Get details from Apple TV instances."""
+        return [self.info_from_entry(entry) for entry in self.get_entries()]


### PR DESCRIPTION
Will find Apple TVs with home sharing enabled and publish HSGID and device name.