### PR TITLE
Add Fluxled discovery.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pyvenv.cfg
 bin
 lib
 pip-selfcheck.json
+.tox

--- a/netdisco/discoverables/flux_led.py
+++ b/netdisco/discoverables/flux_led.py
@@ -1,0 +1,14 @@
+"""Discover Fluxled devices."""
+from . import BaseDiscoverable
+
+
+class Discoverable(BaseDiscoverable):
+    """Add support for discovering a Fluxled device."""
+
+    def __init__(self, netdis):
+        """Initialize the Fluxled discovery."""
+        self._netdis = netdis
+
+    def get_entries(self):
+        """Get all the Fluxled details."""
+        return self._netdis.fluxled.entries

--- a/netdisco/discovery.py
+++ b/netdisco/discovery.py
@@ -10,6 +10,7 @@ from .mdns import MDNS
 from .gdm import GDM
 from .lms import LMS
 from .tellstick import Tellstick
+from .flux_led import FluxLed
 from .daikin import Daikin
 # from .samsungac import SamsungAC
 
@@ -41,6 +42,7 @@ class NetworkDiscovery(object):
         self.gdm = GDM()
         self.lms = LMS()
         self.tellstick = Tellstick()
+        self.fluxled = FluxLed()
         self.daikin = Daikin()
         # self.samsungac = SamsungAC()
         self.discoverables = {}
@@ -68,6 +70,9 @@ class NetworkDiscovery(object):
         tellstick_thread = threading.Thread(target=self.tellstick.scan)
         tellstick_thread.start()
 
+        fluxled_thread = threading.Thread(target=self.fluxled.scan)
+        fluxled_thread.start()
+
         daikin_thread = threading.Thread(target=self.daikin.scan)
         daikin_thread.start()
 
@@ -78,6 +83,7 @@ class NetworkDiscovery(object):
         gdm_thread.join()
         lms_thread.join()
         tellstick_thread.join()
+        fluxled_thread.join()
         daikin_thread.join()
 
     def stop(self):
@@ -149,3 +155,6 @@ class NetworkDiscovery(object):
         print("")
         print("Tellstick")
         pprint(self.tellstick.entries)
+        print("")
+        print("Fluxled")
+        pprint(self.fluxled.entries)

--- a/netdisco/flux_led.py
+++ b/netdisco/flux_led.py
@@ -6,6 +6,8 @@ a packet to every device in the network. This is the way the
 offical app 'Magic Home' does it as well.
 
 """
+
+# pylint:disable=wrong-import-order
 import ipaddress
 import logging
 import socket

--- a/netdisco/flux_led.py
+++ b/netdisco/flux_led.py
@@ -1,0 +1,107 @@
+"""Fluxled device discovery.
+
+Ideally this would be done using broadcast. But some fluxled
+devices do not respond well to broadcast. So instead we send
+a packet to every device in the network. This is the way the
+offical app 'Magic Home' does it as well.
+
+"""
+import socket
+import sys
+import threading
+from datetime import timedelta
+import ipaddress
+from netdisco.util import interface_networks
+import logging
+
+
+DISCOVERY_PORT = 48899
+DISCOVERY_PAYLOAD = "HF-A11ASSISTHREAD".encode('ascii')
+DISCOVERY_TIMEOUT = timedelta(seconds=5)
+
+log = logging.getLogger(__name__)
+
+
+class FluxLed(object):
+    """Base class to discover Fluxled devices."""
+
+    def __init__(self, networks=None):
+        """Initialize the flux_led discovery."""
+        self.entries = []
+        self._lock = threading.RLock()
+
+        # if not explicitly specified determine network from interfaces
+        if networks:
+            self.networks = networks
+        else:
+            self.networks = interface_networks()
+
+    def scan(self):
+        """Scan the network."""
+        with self._lock:
+            self.update()
+
+    def all(self):
+        """Scan and return all found entries."""
+        self.scan()
+        return self.entries
+
+    def update(self):
+        """Scan network for Fluxled devices."""
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(('', DISCOVERY_PORT))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.settimeout(DISCOVERY_TIMEOUT.seconds)
+
+        # send query to every device in every network connected to
+        for network in self.networks:
+            for ip in network.hosts():
+                try:
+                    sock.sendto(DISCOVERY_PAYLOAD, (str(ip), DISCOVERY_PORT))
+                except OSError as exc:
+                    log.debug('failed to send request', exc_info=exc)
+                    continue
+
+        # wait for responses
+        while True:
+            try:
+                data, addr = sock.recvfrom(64)
+            except socket.timeout:
+                # no (more) responses received
+                break
+
+            # skip our own outgoing packet
+            if data == DISCOVERY_PAYLOAD:
+                continue
+
+            # data = ip_address,id,model
+            data = data.decode('ascii').split(',')
+            if len(data) < 3:
+                continue
+
+            entry = tuple(data)
+
+            if entry not in self.entries:
+                self.entries.append(entry)
+
+        sock.close()
+
+
+def main():
+    """Test Tellstick discovery."""
+    from pprint import pprint
+
+    if len(sys.argv) >= 2:
+        networks = [ipaddress.IPv4Network(n) for n in sys.argv[1:]]
+    else:
+        networks = None
+
+    flux_led = FluxLed(networks=networks)
+    pprint("Scanning for FluxLed devices..")
+    flux_led.update()
+    pprint(flux_led.entries)
+
+
+if __name__ == "__main__":
+    main()

--- a/netdisco/flux_led.py
+++ b/netdisco/flux_led.py
@@ -91,7 +91,7 @@ class FluxLed(object):
 
 
 def main():
-    """Test Tellstick discovery."""
+    """Test Fluxled discovery."""
     from pprint import pprint
 
     if len(sys.argv) >= 2:

--- a/netdisco/flux_led.py
+++ b/netdisco/flux_led.py
@@ -34,9 +34,9 @@ class FluxLed(object):
 
         # if not explicitly specified determine network from interfaces
         if networks:
-            self.networks = networks
+            self.networks = set(networks)
         else:
-            self.networks = interface_networks()
+            self.networks = set(interface_networks())
 
     def scan(self):
         """Scan the network."""

--- a/netdisco/util.py
+++ b/netdisco/util.py
@@ -1,5 +1,6 @@
 """Util functions used by Netdisco."""
 from collections import defaultdict
+from ipaddress import IPv4Network
 
 # pylint: disable=unused-import, import-error, no-name-in-module
 try:
@@ -49,3 +50,16 @@ def interface_addresses(family=netifaces.AF_INET):
             for i in netifaces.interfaces()
             for addr in netifaces.ifaddresses(i).get(family) or []
             if 'broadcast' in addr]
+
+
+def interface_networks(family=netifaces.AF_INET):
+    """Return a IPv4Network for any associated network.
+
+    Gathering of networks reachable via local interface that has
+    broadcast (and probably multicast) capability.
+    """
+    # pylint: disable=no-member
+    return [IPv4Network('{}/{}'.format(addr['addr'], addr['netmask']), False)
+            for i in netifaces.interfaces()
+            for addr in netifaces.ifaddresses(i).get(family) or []
+            if 'broadcast' in addr and 'netmask' in addr]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 zeroconf==0.17.5
 requests>=2.0
 netifaces>=0.10.0
+ipaddress==1.0.18; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(name='netdisco',
       author_email='Paulus@PaulusSchoutsen.nl',
       license='Apache License 2.0',
       install_requires=['netifaces>=0.10.0', 'requests>=2.0',
-                        'zeroconf==0.17.6'],
+                        'zeroconf==0.17.6',
+                        'ipaddress==1.0.18; python_version < "3"'],
       packages=find_packages(),
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,11 @@ setup(name='netdisco',
       author_email='Paulus@PaulusSchoutsen.nl',
       license='Apache License 2.0',
       install_requires=['netifaces>=0.10.0', 'requests>=2.0',
-                        'zeroconf==0.17.6',
-                        'ipaddress==1.0.18; python_version < "3"'],
+                        'zeroconf==0.17.6'],
+      extras_require={
+          ':python_version == "2.7"': [
+              'ipaddress',
+          ],
+      },
       packages=find_packages(),
       zip_safe=False)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py34
+[testenv]
+deps=
+  flake8
+  pylint
+commands=
+  flake8 netdisco
+  pylint netdisco


### PR DESCRIPTION
This change adds support for [Fluxled](https://home-assistant.io/components/light.flux_led/) device discovery.

It is partly based on the Tellstick class and the `flux_led` python module: https://github.com/Danielhiversen/flux_led/blob/b48a1b53390360f61fe35a37cc46c948a3a8cb26/flux_led/__main__.py#L957-L1018

But instead of using broadcast, this implementation determines the local networks and sends an UDP query to every possible device on these networks. This more closely matches the method used by the 'Magic Home' app which is the official app for these devices. In my experience (tested on a Arilux RGB controller) broadcast offered bad/flaky discovery with no easy way to improve (multiple send/receive tries, longer timeout, etc).

I have yet to investigate how to make netdisco register devices with HA or if this is something that needs to be added to HA. But otherwise this PR is complete from a functional point of view.

To test using explicit network specified:

    python -m netdisco.flux_led 10.0.0.0/24

Or automatic network detection:

    python -m netdisco.flux_led

Or as part of the complete netdisco application:

    python -m netdisco