### PR TITLE
Implement N-UPnP Philips Hub discovery

### DIFF
--- a/netdisco/discoverables/philips_hue.py
+++ b/netdisco/discoverables/philips_hue.py
@@ -13,8 +13,30 @@ class Discoverable(SSDPDiscoverable):
 
     def get_entries(self):
         """Get all the Hue bridge uPnP entries."""
+        nupnp_entries = self.netdis.phue.entries
+
         # Hub models for year 2012 and 2015
-        return self.find_by_device_description({
+        ssdp_entries = self.find_by_device_description({
             "manufacturer": "Royal Philips Electronics",
             "modelNumber": ["929000226503", "BSB002"]
         })
+
+        return self.merge_entries(nupnp_entries, ssdp_entries)
+
+    # pylint: disable=no-self-use
+    def merge_entries(self, nupnp_entries, ssdp_entries):
+        """Takes lists of device entries found using N-UPnP & SSDP lookups and
+        merges them making sure that same device is only discoverd once.
+
+        """
+        entries = nupnp_entries
+
+        for nupn_entry in entries:
+            for ssdp_entry in ssdp_entries:
+                url_base1 = nupn_entry.description['URLBase']
+                url_base2 = ssdp_entry.description['URLBase']
+
+                if url_base1 != url_base2:
+                    entries.append(ssdp_entry)
+
+        return entries

--- a/netdisco/discovery.py
+++ b/netdisco/discovery.py
@@ -13,6 +13,7 @@ from .tellstick import Tellstick
 from .flux_led import FluxLed
 from .daikin import Daikin
 # from .samsungac import SamsungAC
+from .philips_hue_nupnp import PHueNUPnPDiscovery
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +46,7 @@ class NetworkDiscovery(object):
         self.fluxled = FluxLed()
         self.daikin = Daikin()
         # self.samsungac = SamsungAC()
+        self.phue = PHueNUPnPDiscovery()
         self.discoverables = {}
 
         self._load_device_support()
@@ -78,6 +80,9 @@ class NetworkDiscovery(object):
 
         # self.samsungac.scan()
 
+        phue_thread = threading.Thread(target=self.phue.scan)
+        phue_thread.start()
+
         # Wait for all discovery processes to complete
         ssdp_thread.join()
         gdm_thread.join()
@@ -85,6 +90,7 @@ class NetworkDiscovery(object):
         tellstick_thread.join()
         fluxled_thread.join()
         daikin_thread.join()
+        phue_thread.join()
 
     def stop(self):
         """Turn discovery off."""
@@ -158,3 +164,5 @@ class NetworkDiscovery(object):
         print("")
         print("Fluxled")
         pprint(self.fluxled.entries)
+        print("Philips Hue N-UPnP")
+        pprint(self.phue.entries)

--- a/netdisco/philips_hue_nupnp.py
+++ b/netdisco/philips_hue_nupnp.py
@@ -1,0 +1,76 @@
+"""Philips Hue bridge discovery using N-UPnP.
+
+Philips Hue bridge limits how many SSDP lookups you can make. To work
+around this they recommend to do N-UPnP lookup simultaneously with
+SSDP lookup: https://developers.meethue.com/documentation/hue-bridge-discovery
+
+"""
+
+import xml.etree.ElementTree as ElementTree
+
+import requests
+
+from netdisco.util import etree_to_dict
+
+
+# pylint: disable=too-few-public-methods
+class PHueBridge(object):
+    """Parses Philips Hue bridge description XML into an
+    object similar to UPNPEntry.
+
+    """
+
+    def __init__(self, description_xml):
+        tree = ElementTree.fromstring(description_xml)
+        self.description = etree_to_dict(tree).get("root", {})
+
+    def __repr__(self):
+        friendly_name = self.description['device']['friendlyName']
+        url_base = self.description['URLBase']
+
+        return str((friendly_name, url_base))
+
+
+class PHueNUPnPDiscovery(object):
+    """Philips Hue bridge discovery using N-UPnP."""
+
+    PHUE_NUPNP_URL = "https://www.meethue.com/api/nupnp"
+    DESCRIPTION_URL_TMPL = "http://{}/description.xml"
+
+    def __init__(self):
+        self.entries = []
+
+    def scan(self):
+        """Scan the network."""
+        response = requests.get(self.PHUE_NUPNP_URL)
+        if response.status_code == 200:
+            bridges = response.json()
+            for bridge in bridges:
+                entry = self.fetch_description(bridge)
+                if entry:
+                    self.entries.append(entry)
+
+    def fetch_description(self, bridge):
+        """Fetches description XML of a Philips Hue bridge."""
+        url = self.bridge_description_url(bridge)
+        response = requests.get(url)
+        if response.status_code == 200:
+            return PHueBridge(response.text)
+
+    def bridge_description_url(self, bridge):
+        """Returns URL for fetching description XML"""
+        ipaddr = bridge["internalipaddress"]
+        return self.DESCRIPTION_URL_TMPL.format(ipaddr)
+
+
+def main():
+    """Test N-UPnP discovery."""
+    from pprint import pprint
+
+    disco = PHueNUPnPDiscovery()
+    disco.scan()
+    pprint(disco.entries)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Philips Hue bridge limits how many SSDP lookups you can make. If you
make two consecutive SSDP lookup requests, there won't be any Philips
Hue bridges found in the second lookup attempt.

To work around this Philips recommends to do N-UPnP lookup
simultaneously with SSDP lookup: https://developers.meethue.com/documentation/hue-bridge-discovery

We came across this issue while working on a project that uses Home
Assistant. The Philips Hue bridge was discovered in the morning but
after restarting Home Assistant later it wouldn't get discovered
anymore.