### PR TITLE
Extract only max-age from cache-control header

### DIFF
--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -103,9 +103,13 @@ class UPNPEntry(object):
         self.created = datetime.now()
 
         if 'cache-control' in self.values:
-            cache_seconds = int(self.values['cache-control'].split('=')[1])
-
-            self.expires = self.created + timedelta(seconds=cache_seconds)
+            cache_directive = self.values['cache-control']
+            max_age = re.findall(r'max-age *= *\d+', cache_directive)
+            if (len(max_age) > 0):
+                cache_seconds = int(max_age[0].split('=')[1])
+                self.expires = self.created + timedelta(seconds=cache_seconds)
+            else:
+                self.expires = None
         else:
             self.expires = None
 

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -105,7 +105,7 @@ class UPNPEntry(object):
         if 'cache-control' in self.values:
             cache_directive = self.values['cache-control']
             max_age = re.findall(r'max-age *= *\d+', cache_directive)
-            if (len(max_age) > 0):
+            if len(max_age) > 0:
                 cache_seconds = int(max_age[0].split('=')[1])
                 self.expires = self.created + timedelta(seconds=cache_seconds)
             else:


### PR DESCRIPTION
I found a device on our network which includes additional directives in the `cache-control` header. Specifically the `cache-control` header contained:

`no-cache="Ext", max-age = 5000`

I found the scan failed as it tried to cast `"Ext"` to an int. This PR uses a regex to extract `max-age` directives first and calculate from there. 