### PR TITLE
Fix memory leak by clearing list of Philips Hue bridges on scan

### DIFF
--- a/netdisco/philips_hue_nupnp.py
+++ b/netdisco/philips_hue_nupnp.py
@@ -44,6 +44,7 @@ class PHueNUPnPDiscovery(object):
         """Scan the network."""
         response = requests.get(self.PHUE_NUPNP_URL)
         if response.status_code == 200:
+            self.entries = []
             bridges = response.json()
             for bridge in bridges:
                 entry = self.fetch_description(bridge)


### PR DESCRIPTION
This change clears the 'entries' list in the Philips Hue scanner to prevent the entries list from continually growing, causing a memory leak.

Resolves https://github.com/home-assistant/home-assistant/issues/6239, https://github.com/home-assistant/home-assistant/issues/6165