### PR TITLE
Bugfix exception on close on windows linux subsystem

### DIFF
--- a/netdisco/mdns.py
+++ b/netdisco/mdns.py
@@ -17,11 +17,15 @@ class MDNS(object):
 
     def start(self):
         """Start discovery."""
-        self.zeroconf = zeroconf.Zeroconf()
+        try:
+            self.zeroconf = zeroconf.Zeroconf()
 
-        for service in self.services:
-            self._browsers.append(
-                zeroconf.ServiceBrowser(self.zeroconf, service.typ, service))
+            for service in self.services:
+                self._browsers.append(zeroconf.ServiceBrowser(
+                    self.zeroconf, service.typ, service))
+        except:  # pylint: disable=broad-except
+            self.stop()
+            raise
 
     def stop(self):
         """Stop discovering."""

--- a/netdisco/mdns.py
+++ b/netdisco/mdns.py
@@ -31,8 +31,9 @@ class MDNS(object):
         for service in self.services:
             service.reset()
 
-        self.zeroconf.close()
-        self.zeroconf = None
+        if self.zeroconf:
+            self.zeroconf.close()
+            self.zeroconf = None
 
     @property
     def entries(self):


### PR DESCRIPTION

Fix on windows:

```
17-03-05 19:35:10 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/mnt/d/Fork/home-assistant/homeassistant/components/discovery.py", line 128, in _discover
    netdisco.scan()
  File "/mnt/d/Fork/test-env/lib/python3.4/site-packages/netdisco/discovery.py", line 53, in scan
    self.mdns.start()
  File "/mnt/d/Fork/test-env/lib/python3.4/site-packages/netdisco/mdns.py", line 20, in start
    self.zeroconf = zeroconf.Zeroconf()
  File "/mnt/d/Fork/test-env/lib/python3.4/site-packages/zeroconf.py", line 1660, in __init__
    self._listen_socket = new_socket()
  File "/mnt/d/Fork/test-env/lib/python3.4/site-packages/zeroconf.py", line 1619, in new_socket
    s.setsockopt(socket.SOL_SOCKET, reuseport, 1)
OSError: [Errno 22] Invalid argument

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.4/asyncio/tasks.py", line 234, in _step
    result = coro.throw(exc)
  File "/mnt/d/Fork/home-assistant/homeassistant/components/discovery.py", line 111, in scan_devices
    None, _discover, netdisco)
  File "/usr/lib/python3.4/asyncio/futures.py", line 386, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.4/asyncio/tasks.py", line 287, in _wakeup
    value = future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 275, in result
    raise self._exception
  File "/usr/lib/python3.4/concurrent/futures/thread.py", line 54, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/mnt/d/Fork/home-assistant/homeassistant/components/discovery.py", line 134, in _discover
    netdisco.stop()
  File "/mnt/d/Fork/test-env/lib/python3.4/site-packages/netdisco/discovery.py", line 81, in stop
    self.mdns.stop()
  File "/mnt/d/Fork/test-env/lib/python3.4/site-packages/netdisco/mdns.py", line 34, in stop
    self.zeroconf.close()
AttributeError: 'NoneType' object has no attribute 'close'
```