### PR TITLE
Fix Samsung discovery to only discover once

### DIFF
--- a/netdisco/discoverables/samsung_tv.py
+++ b/netdisco/discoverables/samsung_tv.py
@@ -12,9 +12,7 @@ class Discoverable(SSDPDiscoverable):
 
     def get_entries(self):
         """Get all the Samsung RemoteControlReceiver entries."""
-        return self.find_by_device_description({
-            "deviceType": "urn:samsung.com:device:RemoteControlReceiver:1"
-        })
+        return self.find_by_st("urn:samsung.com:device:RemoteControlReceiver:1")
 
     def info_from_entry(self, entry):
         """Get most important info, by default the description location."""


### PR DESCRIPTION
Samsung TVs were being discovered 4 times. Now it's 1.