### PR TITLE
Version 1.0: Simplify code and return dictionaries

### DIFF
--- a/netdisco/__main__.py
+++ b/netdisco/__main__.py
@@ -1,4 +1,5 @@
 """Command line tool to print discocvered devices or dump raw data."""
+from pprint import pprint
 import sys
 
 from netdisco.discovery import NetworkDiscovery
@@ -10,19 +11,22 @@ def main():
 
     netdisco.scan()
 
-    # Pass in command line argument dump to get the raw data
-    if sys.argv[-1] == 'dump':
-        netdisco.print_raw_data()
-        print()
-        print()
-
     print("Discovered devices:")
     count = 0
     for dev in netdisco.discover():
         count += 1
-        print(dev, netdisco.get_info(dev))
-    print()
+        print('{}:'.format(dev))
+        pprint(netdisco.get_info(dev))
+        print()
     print("Discovered {} devices".format(count))
+
+    # Pass in command line argument dump to get the raw data
+    if sys.argv[-1] == 'dump':
+        print()
+        print()
+        print("Raw Data")
+        print()
+        netdisco.print_raw_data()
 
     netdisco.stop()
 

--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -20,8 +20,15 @@ FRONTIER_SILICON = "frontier_silicon"
 APPLE_TV = "apple_tv"
 HARMONY = "harmony"
 
+ATTR_NAME = 'name'
 ATTR_HOST = 'host'
 ATTR_PORT = 'port'
 ATTR_HOSTNAME = 'hostname'
+ATTR_URLBASE = 'urlbase'
 ATTR_DEVICE_TYPE = 'device_type'
+ATTR_MODEL_NAME = 'model_name'
+ATTR_MODEL_NUMBER = 'model_number'
 ATTR_PROPERTIES = 'properties'
+ATTR_SSDP_DESCRIPTION = 'ssdp_description'
+ATTR_SERIAL = 'serial'
+ATTR_MAC_ADDRESS = 'mac_address'

--- a/netdisco/discoverables/apple_tv.py
+++ b/netdisco/discoverables/apple_tv.py
@@ -1,6 +1,7 @@
 """Discover Apple TV media players."""
 import ipaddress
 from . import MDNSDiscoverable
+from ..const import ATTR_HOST, ATTR_NAME
 
 
 # pylint: disable=too-few-public-methods
@@ -13,13 +14,8 @@ class Discoverable(MDNSDiscoverable):
     def info_from_entry(self, entry):
         """Returns most important info from mDNS entries."""
         props = entry.properties
-        info = {
-            'host': str(ipaddress.ip_address(entry.address)),
-            'name': props.get(b'Name').decode('utf-8').replace('\xa0', ' '),
+        return {
+            ATTR_HOST: str(ipaddress.ip_address(entry.address)),
+            ATTR_NAME: props.get(b'Name').decode('utf-8').replace('\xa0', ' '),
             'hsgid': props.get(b'hG').decode('utf-8')
             }
-        return info
-
-    def get_info(self):
-        """Get details from Apple TV instances."""
-        return [self.info_from_entry(entry) for entry in self.get_entries()]

--- a/netdisco/discoverables/belkin_wemo.py
+++ b/netdisco/discoverables/belkin_wemo.py
@@ -1,5 +1,6 @@
 """Discover Belkin Wemo devices."""
 from . import SSDPDiscoverable
+from ..const import ATTR_MAC_ADDRESS
 
 
 class Discoverable(SSDPDiscoverable):
@@ -7,11 +8,10 @@ class Discoverable(SSDPDiscoverable):
 
     def info_from_entry(self, entry):
         """Return most important info from a uPnP entry."""
+        info = super().info_from_entry(entry)
         device = entry.description['device']
-
-        return (device['friendlyName'], device['modelName'],
-                entry.values['location'], device.get('macAddress', ''),
-                device['serialNumber'])
+        info[ATTR_MAC_ADDRESS] = device.get('macAddress', '')
+        return info
 
     def get_entries(self):
         """Return all Belkin Wemo entries."""

--- a/netdisco/discoverables/denonavr.py
+++ b/netdisco/discoverables/denonavr.py
@@ -2,6 +2,7 @@
 from urllib.parse import urlparse
 
 from . import SSDPDiscoverable
+from ..const import ATTR_HOST
 
 
 class Discoverable(SSDPDiscoverable):
@@ -16,9 +17,7 @@ class Discoverable(SSDPDiscoverable):
 
     def info_from_entry(self, entry):
         """Get most important info, which is name, model and host."""
-        name = entry.description['device']['friendlyName']
-        model = entry.description['device']['modelName']
-        host = urlparse(
+        info = super().info_from_entry(entry)
+        info[ATTR_HOST] = urlparse(
             entry.description['device']['presentationURL']).hostname
-
-        return (host, name, model)
+        return info

--- a/netdisco/discoverables/directv.py
+++ b/netdisco/discoverables/directv.py
@@ -1,18 +1,9 @@
 """Discover DirecTV Receivers."""
-from netdisco.util import urlparse
 from . import SSDPDiscoverable
 
 
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering DirecTV Receivers."""
-
-    def info_from_entry(self, entry):
-        """Return the most important info from a uPnP entry."""
-        url = urlparse(entry.values['location'])
-
-        device = entry.description['device']
-
-        return url.hostname, device['serialNumber']
 
     def get_entries(self):
         """Get all the DirecTV uPnP entries."""

--- a/netdisco/discoverables/harmony.py
+++ b/netdisco/discoverables/harmony.py
@@ -1,18 +1,9 @@
 """Discover Netgear routers."""
-from netdisco.util import urlparse
 from . import SSDPDiscoverable
 
 
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering Harmony Hub remotes"""
-
-    def info_from_entry(self, entry):
-        """Return the most important info from a uPnP entry."""
-        url = urlparse(entry.values['location'])
-        return {
-            'name': entry.description['device']['friendlyName'],
-            'host': url.hostname,
-            }
 
     def get_entries(self):
         """Get all the Harmony uPnP entries."""

--- a/netdisco/discoverables/hass_ios.py
+++ b/netdisco/discoverables/hass_ios.py
@@ -8,14 +8,3 @@ class Discoverable(MDNSDiscoverable):
 
     def __init__(self, nd):
         super(Discoverable, self).__init__(nd, '_hass-ios._tcp.local.')
-
-    def info_from_entry(self, entry):
-        """Returns most important info from mDNS entries."""
-        return (entry.properties.get(b'buildNumber').decode('utf-8'),
-                entry.properties.get(b'versionNumber').decode('utf-8'),
-                entry.properties.get(b'permanentID').decode('utf-8'),
-                entry.properties.get(b'bundleIdentifer').decode('utf-8'))
-
-    def get_info(self):
-        """Get details from Home Assistant iOS app instances."""
-        return [self.info_from_entry(entry) for entry in self.get_entries()]

--- a/netdisco/discoverables/home_assistant.py
+++ b/netdisco/discoverables/home_assistant.py
@@ -8,13 +8,3 @@ class Discoverable(MDNSDiscoverable):
 
     def __init__(self, nd):
         super(Discoverable, self).__init__(nd, '_home-assistant._tcp.local.')
-
-    def info_from_entry(self, entry):
-        """Returns most important info from mDNS entries."""
-        return (entry.properties.get(b'base_url').decode('utf-8'),
-                entry.properties.get(b'version').decode('utf-8'),
-                entry.properties.get(b'requires_api_password'))
-
-    def get_info(self):
-        """Get details from Home Assistant instances."""
-        return [self.info_from_entry(entry) for entry in self.get_entries()]

--- a/netdisco/discoverables/homekit.py
+++ b/netdisco/discoverables/homekit.py
@@ -1,6 +1,5 @@
 """Discover myStrom devices."""
 from . import MDNSDiscoverable
-from ..const import ATTR_HOST
 
 
 # pylint: disable=too-few-public-methods
@@ -9,14 +8,3 @@ class Discoverable(MDNSDiscoverable):
 
     def __init__(self, nd):
         super(Discoverable, self).__init__(nd, '_hap._tcp.local.')
-
-    def info_from_entry(self, entry):
-        """Return the most important info from mDNS entries."""
-        info = {key.decode('utf-8'): value.decode('utf-8')
-                for key, value in entry.properties.items()}
-        info[ATTR_HOST] = 'http://{}'.format(self.ip_from_host(entry.server))
-        return info
-
-    def get_info(self):
-        """Get details from myStrom devices."""
-        return [self.info_from_entry(entry) for entry in self.get_entries()]

--- a/netdisco/discoverables/kodi.py
+++ b/netdisco/discoverables/kodi.py
@@ -10,9 +10,5 @@ class Discoverable(MDNSDiscoverable):
         """Initialize the Kodi discovery."""
         super(Discoverable, self).__init__(nd, '_http._tcp.local.')
 
-    def info_from_entry(self, entry):
-        """Return most important info from mDNS entries."""
-        return (self.ip_from_host(entry.server), entry.port)
-
     def get_entries(self):
         return self.find_by_device_name('Kodi ')

--- a/netdisco/discoverables/netgear_router.py
+++ b/netdisco/discoverables/netgear_router.py
@@ -1,16 +1,9 @@
 """Discover Netgear routers."""
-from netdisco.util import urlparse
 from . import SSDPDiscoverable
 
 
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering Netgear routers."""
-
-    def info_from_entry(self, entry):
-        """Return the most important info from a uPnP entry."""
-        url = urlparse(entry.values['location'])
-
-        return (entry.description['device']['modelNumber'], url.hostname)
 
     def get_entries(self):
         """Get all the Netgear uPnP entries."""

--- a/netdisco/discoverables/openhome.py
+++ b/netdisco/discoverables/openhome.py
@@ -6,11 +6,6 @@ from . import SSDPDiscoverable
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering Openhome compliant devices."""
 
-    def info_from_entry(self, entry):
-        """Return the most important info from a uPnP entry."""
-        return (entry.description['device']['friendlyName'],
-                entry.values['location'])
-
     def get_entries(self):
         """Get all the Openhome compliant device uPnP entries."""
         return self.find_by_st("urn:av-openhome-org:service:Product:2")

--- a/netdisco/discoverables/panasonic_viera.py
+++ b/netdisco/discoverables/panasonic_viera.py
@@ -1,16 +1,10 @@
 """Discover Panasonic Viera TV devices."""
-from netdisco.util import urlparse
 from . import SSDPDiscoverable
 
 
 # pylint: disable=too-few-public-methods
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering Viera TV devices."""
-
-    def info_from_entry(self, entry):
-        """Return the most important info from a uPnP entry."""
-        parsed = urlparse(entry.values['location'])
-        return '{}:{}'.format(parsed.hostname, parsed.port)
 
     def get_entries(self):
         """Get all the Viera TV device uPnP entries."""

--- a/netdisco/discoverables/philips_hue.py
+++ b/netdisco/discoverables/philips_hue.py
@@ -5,12 +5,6 @@ from . import SSDPDiscoverable
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering Philips Hue bridges."""
 
-    def info_from_entry(self, entry):
-        """Return the most important info from a uPnP entry."""
-        desc = entry.description
-
-        return desc['device']['friendlyName'], desc['URLBase']
-
     def get_entries(self):
         """Get all the Hue bridge uPnP entries."""
         nupnp_entries = self.netdis.phue.entries

--- a/netdisco/discoverables/plex_mediaserver.py
+++ b/netdisco/discoverables/plex_mediaserver.py
@@ -1,5 +1,6 @@
 """Discover PlexMediaServer."""
 from . import GDMDiscoverable
+from ..const import ATTR_NAME, ATTR_HOST, ATTR_PORT, ATTR_URLBASE
 
 
 class Discoverable(GDMDiscoverable):
@@ -7,8 +8,13 @@ class Discoverable(GDMDiscoverable):
 
     def info_from_entry(self, entry):
         """Return most important info from a GDM entry."""
-        return (entry['data']['Name'],
-                'https://%s:%s' % (entry['from'][0], entry['data']['Port']))
+        return {
+            ATTR_NAME: entry['data']['Name'],
+            ATTR_HOST: entry['from'][0],
+            ATTR_PORT: entry['data']['Port'],
+            ATTR_URLBASE: 'https://%s:%s' % (entry['from'][0],
+                                             entry['data']['Port'])
+        }
 
     def get_entries(self):
         """Return all PMS entries."""

--- a/netdisco/discoverables/roku.py
+++ b/netdisco/discoverables/roku.py
@@ -1,15 +1,9 @@
 """Discover Roku players."""
-from netdisco.util import urlparse
 from . import SSDPDiscoverable
 
 
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering Roku media players."""
-
-    def info_from_entry(self, entry):
-        """Return the most important info from a uPnP entry."""
-        info = urlparse(entry.location)
-        return info.hostname, info.port
 
     def get_entries(self):
         """Get all the Roku entries."""

--- a/netdisco/discoverables/sabnzbd.py
+++ b/netdisco/discoverables/sabnzbd.py
@@ -10,10 +10,5 @@ class Discoverable(MDNSDiscoverable):
         """Initialize the SABnzbd discovery."""
         super(Discoverable, self).__init__(nd, '_http._tcp.local.')
 
-    def info_from_entry(self, entry):
-        """Return most important info from mDNS entries."""
-        return (self.ip_from_host(entry.server), entry.port,
-                entry.properties.get('path', '/sabnzbd/'))
-
     def get_entries(self):
         return self.find_by_device_name('SABnzbd on')

--- a/netdisco/discoverables/samsung_tv.py
+++ b/netdisco/discoverables/samsung_tv.py
@@ -1,7 +1,6 @@
 """Discover Samsung Smart TV services."""
-from urllib.parse import urlparse
-
 from . import SSDPDiscoverable
+from ..const import ATTR_NAME
 
 # For some models, Samsung forces a [TV] prefix to the user-specified name.
 FORCED_NAME_PREFIX = '[TV]'
@@ -12,19 +11,15 @@ class Discoverable(SSDPDiscoverable):
 
     def get_entries(self):
         """Get all the Samsung RemoteControlReceiver entries."""
-        return self.find_by_st("urn:samsung.com:device:RemoteControlReceiver:1")
+        return self.find_by_st(
+            "urn:samsung.com:device:RemoteControlReceiver:1")
 
     def info_from_entry(self, entry):
         """Get most important info, by default the description location."""
+        info = super().info_from_entry(entry)
 
-        name = entry.description['device']['friendlyName']
         # Strip the forced prefix, if present
-        if name.startswith(FORCED_NAME_PREFIX):
-            name = name[len(FORCED_NAME_PREFIX):]
+        if info[ATTR_NAME].startswith(FORCED_NAME_PREFIX):
+            info[ATTR_NAME] = info[ATTR_NAME][len(FORCED_NAME_PREFIX):].strip()
 
-        model = entry.description['device']['modelName']
-
-        # Extract the IP address from the location; it is not given in the XML.
-        host = urlparse(entry.values['location']).hostname
-
-        return name, model, host
+        return info

--- a/netdisco/discoverables/sonos.py
+++ b/netdisco/discoverables/sonos.py
@@ -1,15 +1,10 @@
 """Discover Sonos devices."""
-from netdisco.util import urlparse
 from . import SSDPDiscoverable
 
 
 # pylint: disable=too-few-public-methods
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering Sonos devices."""
-
-    def info_from_entry(self, entry):
-        """Return the most important info from a uPnP entry."""
-        return urlparse(entry.values['location']).hostname
 
     def get_entries(self):
         """Get all the Sonos device uPnP entries."""

--- a/netdisco/discoverables/webos_tv.py
+++ b/netdisco/discoverables/webos_tv.py
@@ -1,15 +1,10 @@
 """Discover LG WebOS TV devices."""
-from netdisco.util import urlparse
 from . import SSDPDiscoverable
 
 
 # pylint: disable=too-few-public-methods
 class Discoverable(SSDPDiscoverable):
     """Add support for discovering LG WebOS TV devices."""
-
-    def info_from_entry(self, entry):
-        """Return the most important info from a uPnP entry."""
-        return urlparse(entry.values['location']).hostname
 
     def get_entries(self):
         """Get all the LG WebOS TV device uPnP entries."""

--- a/netdisco/discoverables/yamaha.py
+++ b/netdisco/discoverables/yamaha.py
@@ -10,6 +10,8 @@ class Discoverable(SSDPDiscoverable):
 
     def info_from_entry(self, entry):
         """Return the most important info from a uPnP entry."""
+        info = super().info_from_entry(entry)
+
         yam = entry.description['X_device']
         services = yam['X_serviceList']['X_service']
         if isinstance(services, list):
@@ -20,11 +22,11 @@ class Discoverable(SSDPDiscoverable):
         else:
             service = services
         # do a slice of the second element so we don't have double /
-        ctrlurl = (yam['X_URLBase'] + service['X_controlURL'][1:])
-        descurl = (yam['X_URLBase'] + service['X_unitDescURL'][1:])
-        device = entry.description['device']
+        info['control_url'] = yam['X_URLBase'] + service['X_controlURL'][1:]
+        info['description_url'] = (yam['X_URLBase'] +
+                                   service['X_unitDescURL'][1:])
 
-        return (device['friendlyName'], device['modelName'], ctrlurl, descurl)
+        return info
 
     def get_entries(self):
         """Get all the Yamaha uPnP entries."""

--- a/netdisco/discoverables/yeelight.py
+++ b/netdisco/discoverables/yeelight.py
@@ -1,8 +1,7 @@
 """Discover Yeelight bulbs, based on Kodi discoverable."""
 import logging
 from . import MDNSDiscoverable
-from ..const import (
-    ATTR_HOST, ATTR_PORT, ATTR_HOSTNAME, ATTR_DEVICE_TYPE, ATTR_PROPERTIES)
+from ..const import ATTR_DEVICE_TYPE
 
 
 # pylint: disable=too-few-public-methods
@@ -15,6 +14,7 @@ class Discoverable(MDNSDiscoverable):
 
     def info_from_entry(self, entry):
         """Return most important info from mDNS entries."""
+        info = super().info_from_entry(entry)
 
         device_type = "UNKNOWN"
         if entry.name.startswith("yeelink-light-color1_"):
@@ -24,17 +24,8 @@ class Discoverable(MDNSDiscoverable):
         else:
             logging.warning("Unknown miio device found: %s", entry)
 
-        def _decode_properties(props):
-            return {x.decode("utf-8"): props[x].decode("utf-8")
-                    for x in props}
-
-        return {
-            ATTR_HOST: self.ip_from_host(entry.server),
-            ATTR_PORT: entry.port,
-            ATTR_HOSTNAME: entry.server,
-            ATTR_DEVICE_TYPE: device_type,
-            ATTR_PROPERTIES: _decode_properties(entry.properties)
-        }
+        info[ATTR_DEVICE_TYPE] = device_type
+        return info
 
     def get_entries(self):
         """ Return yeelight devices. """

--- a/netdisco/philips_hue_nupnp.py
+++ b/netdisco/philips_hue_nupnp.py
@@ -23,7 +23,8 @@ class PHueBridge(object):
 
     """
 
-    def __init__(self, description_xml):
+    def __init__(self, location, description_xml):
+        self.location = location
         tree = ElementTree.fromstring(description_xml)
         self.description = etree_to_dict(tree).get("root", {})
 
@@ -65,7 +66,7 @@ class PHueNUPnPDiscovery(object):
         try:
             response = requests.get(url, timeout=5)
             response.raise_for_status()
-            return PHueBridge(response.text)
+            return PHueBridge(url, response.text)
         except requests.exceptions.RequestException as err:
             _LOGGER.warning('Could not query server %s: %s',
                             url, err)

--- a/netdisco/util.py
+++ b/netdisco/util.py
@@ -1,13 +1,6 @@
 """Util functions used by Netdisco."""
 from collections import defaultdict
 
-# pylint: disable=unused-import, import-error, no-name-in-module
-try:
-    # Py2
-    from urlparse import urlparse  # noqa
-except ImportError:
-    # Py3
-    from urllib.parse import urlparse  # noqa
 import netifaces
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 zeroconf==0.19
 requests>=2.0
-netifaces>=0.10.0
+# For now we depend on netifaces via zeroconf
+# netifaces

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
 from setuptools import setup, find_packages
 
 setup(name='netdisco',
-      version='0.9.2',
+      version='1.0.0.rc1',
       description='Discover devices on your local network',
       url='https://github.com/home-assistant/netdisco',
       author='Paulus Schoutsen',
       author_email='Paulus@PaulusSchoutsen.nl',
       license='Apache License 2.0',
-      install_requires=['netifaces>=0.10.0', 'requests>=2.0',
-                        'zeroconf==0.17.6'],
+      install_requires=['requests>=2.0', 'zeroconf==0.19'],
       packages=find_packages(exclude=['tests', 'tests.*']),
       zip_safe=False)

--- a/tests/discoverables/test_yamaha.py
+++ b/tests/discoverables/test_yamaha.py
@@ -5,9 +5,13 @@ import xml.etree.ElementTree as ElementTree
 from netdisco.discoverables.yamaha import Discoverable
 from netdisco.util import etree_to_dict
 
+LOCATION = 'http://192.168.XXX.XXX:80/desc.xml'
+
 
 class MockUPNPEntry(object):
     """UPNPEntry backed by a description file."""
+
+    location = LOCATION
 
     def __init__(self, name):
         """Read and parse a MockUPNPEntry from a file."""
@@ -16,37 +20,78 @@ class MockUPNPEntry(object):
             self.description = etree_to_dict(
                 ElementTree.fromstring(content.read())).get('root', {})
 
+
 class TestYamaha(unittest.TestCase):
     """Test the Yamaha Discoverable."""
 
     def test_info_from_entry_rx_v481(self):
         self.assertEqual(
-            ("RX-V481 XXXXXX", "RX-V481",
-             "http://192.168.XXX.XXX:80/YamahaRemoteControl/ctrl",
-             "http://192.168.XXX.XXX:80/YamahaRemoteControl/desc.xml"),
             Discoverable(None).info_from_entry(
-                MockUPNPEntry("desc_RX-V481.xml")))
+                MockUPNPEntry("desc_RX-V481.xml")),
+            {
+                'control_url':
+                'http://192.168.XXX.XXX:80/YamahaRemoteControl/ctrl',
+                'description_url':
+                'http://192.168.XXX.XXX:80/YamahaRemoteControl/desc.xml',
+                'host': '192.168.xxx.xxx',
+                'model_name': 'RX-V481',
+                'model_number': 'V481',
+                'name': 'RX-V481 XXXXXX',
+                'port': 80,
+                'serial': 'XXXXXXXX',
+                'ssdp_description': 'http://192.168.XXX.XXX:80/desc.xml'
+            })
 
     def test_info_from_entry_single_service(self):
         self.assertEqual(
-            ("single service friendly name", "single service model name",
-             "http://192.168.1.2:80/YamahaRemoteControl/single_ctrl",
-             "http://192.168.1.2:80/YamahaRemoteControl/single_desc.xml"),
             Discoverable(None).info_from_entry(
-                MockUPNPEntry("desc_single_service.xml")))
+                MockUPNPEntry("desc_single_service.xml")),
+            {
+                'control_url':
+                'http://192.168.1.2:80/YamahaRemoteControl/single_ctrl',
+                'description_url':
+                'http://192.168.1.2:80/YamahaRemoteControl/single_desc.xml',
+                'host': '192.168.xxx.xxx',
+                'model_name': 'single service model name',
+                'model_number': None,
+                'name': 'single service friendly name',
+                'port': 80,
+                'serial': None,
+                'ssdp_description': 'http://192.168.XXX.XXX:80/desc.xml'
+            })
 
     def test_info_from_entry_multiple_services_remote_control_last(self):
         self.assertEqual(
-            ("multi service friendly name", "multi service model name",
-             "http://192.168.1.2:80/YamahaRemoteControl/multi_ctrl",
-             "http://192.168.1.2:80/YamahaRemoteControl/multi_desc.xml"),
             Discoverable(None).info_from_entry(MockUPNPEntry(
-                "desc_multiple_services_remote_control_last.xml")))
+                "desc_multiple_services_remote_control_last.xml")),
+            {
+                'control_url':
+                'http://192.168.1.2:80/YamahaRemoteControl/multi_ctrl',
+                'description_url':
+                'http://192.168.1.2:80/YamahaRemoteControl/multi_desc.xml',
+                'host': '192.168.xxx.xxx',
+                'model_name': 'multi service model name',
+                'model_number': None,
+                'name': 'multi service friendly name',
+                'port': 80,
+                'serial': None,
+                'ssdp_description': 'http://192.168.XXX.XXX:80/desc.xml'
+            })
 
     def test_info_from_entry_multiple_services_no_remote_control(self):
         self.assertEqual(
-            ("multi service friendly name", "multi service model name",
-             "http://192.168.1.2:80/YamahaNewControl/ctrl",
-             "http://192.168.1.2:80/YamahaNewControl/desc.xml"),
             Discoverable(None).info_from_entry(MockUPNPEntry(
-                "desc_multiple_services_no_remote_control.xml")))
+                "desc_multiple_services_no_remote_control.xml")),
+            {
+                'control_url':
+                'http://192.168.1.2:80/YamahaNewControl/ctrl',
+                'description_url':
+                'http://192.168.1.2:80/YamahaNewControl/desc.xml',
+                'host': '192.168.xxx.xxx',
+                'model_name': 'multi service model name',
+                'model_number': None,
+                'name': 'multi service friendly name',
+                'port': 80,
+                'serial': None,
+                'ssdp_description': 'http://192.168.XXX.XXX:80/desc.xml'
+            })


### PR DESCRIPTION
This simplifies the code, cleans up unnecessary code paths and ensures that `info_from_entry` always returns a dictionary.

Fixes #72

This will require us to go through all the discoverable components and platforms in Home Assistant and make sure that they expect `discovery_info` to be a dictionary.