### PR TITLE
Add exception handlers + logging to netdisc modules

### DIFF
--- a/netdisco/daikin.py
+++ b/netdisco/daikin.py
@@ -50,9 +50,8 @@ class Daikin(object):
                 sock.bind(("", UDP_SRC_PORT))
 
                 sock.sendto(DISCOVERY_MSG, (DISCOVERY_ADDRESS, UDP_DST_PORT))
-            except Exception as e:
-                _LOGGER.exception("daikin: Exception sending msg: %s",
-                                  str(e))
+            except socket.error as err:
+                _LOGGER.error("daikin: Error sending: %s", str(err))
                 self.entries = []
                 return
 
@@ -89,9 +88,8 @@ class Daikin(object):
 
                 except socket.timeout:
                     break
-                except Exception as e:
-                    _LOGGER.exception("daikin: Exception in receiving msg: %s",
-                                      str(e))
+                except socket.error as err:
+                    _LOGGER.error("daikin: Error in receiving msg: %s", str(err))
 
         self.entries = entries
 

--- a/netdisco/daikin.py
+++ b/netdisco/daikin.py
@@ -22,6 +22,7 @@ DISCOVERY_TIMEOUT = timedelta(seconds=5)
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class Daikin(object):
     """Base class to discover Daikin devices."""
 
@@ -47,11 +48,11 @@ class Daikin(object):
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 sock.settimeout(DISCOVERY_TIMEOUT.seconds)
                 sock.bind(("", UDP_SRC_PORT))
-                
+
                 sock.sendto(DISCOVERY_MSG, (DISCOVERY_ADDRESS, UDP_DST_PORT))
             except Exception as e:
                 _LOGGER.exception("daikin: Exception sending msg: %s",
-                                str(e))
+                                  str(e))
                 self.entries = []
                 return
 

--- a/netdisco/daikin.py
+++ b/netdisco/daikin.py
@@ -1,5 +1,6 @@
 """Daikin device discovery."""
 import socket
+import logging
 
 # pylint: disable=unused-import, import-error, no-name-in-module
 try:
@@ -19,6 +20,7 @@ UDP_DST_PORT = 30050
 DISCOVERY_ADDRESS = '<broadcast>'
 DISCOVERY_TIMEOUT = timedelta(seconds=5)
 
+_LOGGER = logging.getLogger(__name__)
 
 class Daikin(object):
     """Base class to discover Daikin devices."""
@@ -40,14 +42,18 @@ class Daikin(object):
         """Scan network for Daikin devices."""
         entries = []
 
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        sock.settimeout(DISCOVERY_TIMEOUT.seconds)
-        sock.bind(("", UDP_SRC_PORT))
-
-        try:
-
-            sock.sendto(DISCOVERY_MSG, (DISCOVERY_ADDRESS, UDP_DST_PORT))
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+                sock.settimeout(DISCOVERY_TIMEOUT.seconds)
+                sock.bind(("", UDP_SRC_PORT))
+                
+                sock.sendto(DISCOVERY_MSG, (DISCOVERY_ADDRESS, UDP_DST_PORT))
+            except Exception as e:
+                _LOGGER.exception("daikin: Exception sending msg: %s",
+                                str(e))
+                self.entries = []
+                return
 
             while True:
                 try:
@@ -82,9 +88,9 @@ class Daikin(object):
 
                 except socket.timeout:
                     break
-
-        finally:
-            sock.close()
+                except Exception as e:
+                    _LOGGER.exception("daikin: Exception in receiving msg: %s",
+                                      str(e))
 
         self.entries = entries
 

--- a/netdisco/daikin.py
+++ b/netdisco/daikin.py
@@ -89,7 +89,8 @@ class Daikin(object):
                 except socket.timeout:
                     break
                 except socket.error as err:
-                    _LOGGER.error("daikin: Error in receiving msg: %s", str(err))
+                    _LOGGER.error("daikin: Error in receiving msg: %s",
+                                  str(err))
 
         self.entries = entries
 

--- a/netdisco/lms.py
+++ b/netdisco/lms.py
@@ -33,10 +33,16 @@ class LMS(object):
 
         entries = []
 
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        sock.settimeout(lms_timeout)
-        sock.bind(('', 0))
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            sock.settimeout(lms_timeout)
+            sock.bind(('', 0))
+        except Exception as e:
+            _LOGGER.exception("lms: Exception in binding socketg: %s",
+                              str(e))
+            self.entries = []  
+            return
 
         try:
             sock.sendto(lms_msg, (lms_ip, lms_port))
@@ -57,6 +63,10 @@ class LMS(object):
                             ATTR_PORT: port,
                         })
                 except socket.timeout:
+                    break
+                except Exception as e:
+                    _LOGGER.exception("lms: Exception in receiving: %s",
+                                      str(e))
                     break
         finally:
             sock.close()

--- a/netdisco/lms.py
+++ b/netdisco/lms.py
@@ -1,13 +1,14 @@
 """Squeezebox/Logitech Media server discovery."""
 import socket
-import logger
+import logging
 
 from .const import ATTR_HOST, ATTR_PORT
 
 DISCOVERY_PORT = 3483
 DEFAULT_DISCOVERY_TIMEOUT = 5
 
-_LOGGER =  logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
+
 
 class LMS(object):
     """Base class to discover Logitech Media servers."""
@@ -43,7 +44,7 @@ class LMS(object):
         except Exception as e:
             _LOGGER.exception("lms: Exception in binding socketg: %s",
                               str(e))
-            self.entries = []  
+            self.entries = []
             return
 
         try:

--- a/netdisco/lms.py
+++ b/netdisco/lms.py
@@ -41,9 +41,8 @@ class LMS(object):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
             sock.settimeout(lms_timeout)
             sock.bind(('', 0))
-        except Exception as e:
-            _LOGGER.exception("lms: Exception in binding socketg: %s",
-                              str(e))
+        except socket.error as err:
+            _LOGGER.error("lms: Error in binding socketg: %s", str(err))
             self.entries = []
             return
 
@@ -67,9 +66,8 @@ class LMS(object):
                         })
                 except socket.timeout:
                     break
-                except Exception as e:
-                    _LOGGER.exception("lms: Exception in receiving: %s",
-                                      str(e))
+                except socket.error as err:
+                    _LOGGER.error("lms: Error in receiving: %s", str(err))
                     break
         finally:
             sock.close()

--- a/netdisco/lms.py
+++ b/netdisco/lms.py
@@ -1,11 +1,13 @@
 """Squeezebox/Logitech Media server discovery."""
 import socket
+import logger
 
 from .const import ATTR_HOST, ATTR_PORT
 
 DISCOVERY_PORT = 3483
 DEFAULT_DISCOVERY_TIMEOUT = 5
 
+_LOGGER =  logging.getLogger(__name__)
 
 class LMS(object):
     """Base class to discover Logitech Media servers."""

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -24,7 +24,8 @@ ST_ALL = "ssdp:all"
 # Devices only, some devices will only respond to this query
 ST_ROOTDEVICE = "upnp:rootdevice"
 
-_LOGGER =  logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
+
 
 class SSDP(object):
     """Control the scanning of uPnP devices and services and caches output."""
@@ -217,7 +218,7 @@ def scan(timeout=DISCOVER_TIMEOUT):
                             SSDP_MX)
             sock.bind((addr, 0))
             sockets.append(sock)
-        except socket.error:
+        except socket.error as e:
             _LOGGER.exception("Error binding to %s: %s", str(addr), str(e))
             pass
 
@@ -244,7 +245,8 @@ def scan(timeout=DISCOVER_TIMEOUT):
                 try:
                     response = sock.recv(1024).decode("utf-8")
                 except socket.error:
-                    _LOGGER.exception("Socket error while discovering SSDP devices")
+                    _LOGGER.exception("Socket error while discovering SSDP "
+                                      "devices")
                     sockets.remove(sock)
                     sock.close()
                     continue

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -220,7 +220,6 @@ def scan(timeout=DISCOVER_TIMEOUT):
             sockets.append(sock)
         except socket.error as e:
             _LOGGER.exception("Error binding to %s: %s", str(addr), str(e))
-            pass
 
     entries = {}
     for sock in [s for s in sockets]:

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -24,6 +24,7 @@ ST_ALL = "ssdp:all"
 # Devices only, some devices will only respond to this query
 ST_ROOTDEVICE = "upnp:rootdevice"
 
+_LOGGER =  logging.getLogger(__name__)
 
 class SSDP(object):
     """Control the scanning of uPnP devices and services and caches output."""
@@ -139,14 +140,12 @@ class UPNPEntry(object):
                 UPNPEntry.DESCRIPTION_CACHE[url] = \
                     etree_to_dict(tree).get('root', {})
             except requests.RequestException:
-                logging.getLogger(__name__).warning(
-                    "Error fetching description at %s", url)
+                _LOGGER.warning("Error fetching description at %s", url)
 
                 UPNPEntry.DESCRIPTION_CACHE[url] = {}
 
             except ElementTree.ParseError:
-                logging.getLogger(__name__).warning(
-                    "Found malformed XML at %s: %s", url, xml)
+                _LOGGER.warning("Found malformed XML at %s: %s", url, xml)
 
                 UPNPEntry.DESCRIPTION_CACHE[url] = {}
 
@@ -219,6 +218,7 @@ def scan(timeout=DISCOVER_TIMEOUT):
             sock.bind((addr, 0))
             sockets.append(sock)
         except socket.error:
+            _LOGGER.exception("Error binding to %s: %s", str(addr), str(e))
             pass
 
     entries = {}
@@ -244,15 +244,13 @@ def scan(timeout=DISCOVER_TIMEOUT):
                 try:
                     response = sock.recv(1024).decode("utf-8")
                 except socket.error:
-                    logging.getLogger(__name__).exception(
-                        "Socket error while discovering SSDP devices")
+                    _LOGGER.exception("Socket error while discovering SSDP devices")
                     sockets.remove(sock)
                     sock.close()
                     continue
 
                 entry = UPNPEntry.from_response(response)
                 entries[(entry.st, entry.location)] = entry
-
     finally:
         for s in sockets:
             s.close()

--- a/netdisco/tellstick.py
+++ b/netdisco/tellstick.py
@@ -29,12 +29,18 @@ class Tellstick(object):
         """Scan network for Tellstick devices."""
         entries = []
 
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.settimeout(DISCOVERY_TIMEOUT.seconds)
-        sock.sendto(DISCOVERY_PAYLOAD, (DISCOVERY_ADDRESS, DISCOVERY_PORT))
-
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.settimeout(DISCOVERY_TIMEOUT.seconds)
+            sock.sendto(DISCOVERY_PAYLOAD, (DISCOVERY_ADDRESS, DISCOVERY_PORT))
+        except Exception as e:
+            _LOGGER.exception("tellstick: Exception in sending: %s",
+                              str(e))
+            self.entries = []
+            return
+        
         while True:
             try:
                 data, (address, _) = sock.recvfrom(1024)
@@ -46,6 +52,10 @@ class Tellstick(object):
                 entries.append(entry)
 
             except socket.timeout:
+                break
+            except Exception as e:
+                _LOGGER.exception("tellstick: Exception in receiving: %s",
+                                  str(e))
                 break
 
             self.entries = entries

--- a/netdisco/tellstick.py
+++ b/netdisco/tellstick.py
@@ -37,9 +37,8 @@ class Tellstick(object):
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.settimeout(DISCOVERY_TIMEOUT.seconds)
             sock.sendto(DISCOVERY_PAYLOAD, (DISCOVERY_ADDRESS, DISCOVERY_PORT))
-        except Exception as e:
-            _LOGGER.exception("tellstick: Exception in sending: %s",
-                              str(e))
+        except socket.error as err:
+            _LOGGER.error("tellstick: Error in sending: %s", str(err))
             self.entries = []
             return
 
@@ -55,9 +54,9 @@ class Tellstick(object):
 
             except socket.timeout:
                 break
-            except Exception as e:
-                _LOGGER.exception("tellstick: Exception in receiving: %s",
-                                  str(e))
+            except socket.error as err:
+                _LOGGER.error("tellstick: Error in receiving: %s",
+                              str(err))
                 break
 
             self.entries = entries

--- a/netdisco/tellstick.py
+++ b/netdisco/tellstick.py
@@ -1,14 +1,15 @@
 """Tellstick device discovery."""
 import socket
 from datetime import timedelta
-import logger
+import logging
 
 DISCOVERY_PORT = 30303
 DISCOVERY_ADDRESS = '<broadcast>'
 DISCOVERY_PAYLOAD = b"D"
 DISCOVERY_TIMEOUT = timedelta(seconds=5)
 
-_LOGGER =  logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
+
 
 class Tellstick(object):
     """Base class to discover Tellstick devices."""
@@ -41,7 +42,7 @@ class Tellstick(object):
                               str(e))
             self.entries = []
             return
-        
+
         while True:
             try:
                 data, (address, _) = sock.recvfrom(1024)

--- a/netdisco/tellstick.py
+++ b/netdisco/tellstick.py
@@ -1,13 +1,14 @@
 """Tellstick device discovery."""
 import socket
 from datetime import timedelta
-
+import logger
 
 DISCOVERY_PORT = 30303
 DISCOVERY_ADDRESS = '<broadcast>'
 DISCOVERY_PAYLOAD = b"D"
 DISCOVERY_TIMEOUT = timedelta(seconds=5)
 
+_LOGGER =  logging.getLogger(__name__)
 
 class Tellstick(object):
     """Base class to discover Tellstick devices."""


### PR DESCRIPTION
Exceptions in the modules may interrupt entire discovery pipeline by failing to bind(), recv(), send() etc. Now allows discovery to continue with next class of devices.