### PR TITLE
ssdp.py - nonetype locations no longer fail

### DIFF
--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -267,7 +267,8 @@ def scan(timeout=DISCOVER_TIMEOUT):
         for s in sockets:
             s.close()
 
-    return sorted(entries.values(), key=lambda \
+    return sorted(
+       entries.values(), key=lambda
        entry: entry.location if isinstance(entry.location, str) else "")
 
 

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -267,7 +267,7 @@ def scan(timeout=DISCOVER_TIMEOUT):
         for s in sockets:
             s.close()
 
-    return sorted(entries.values(), key=lambda entry: entry.location)
+    return sorted(entries.values(), key=lambda entry: entry.location if isinstance(entry.location, str) else "")
 
 
 def main():

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -267,7 +267,8 @@ def scan(timeout=DISCOVER_TIMEOUT):
         for s in sockets:
             s.close()
 
-    return sorted(entries.values(), key=lambda entry: entry.location if isinstance(entry.location, str) else "")
+    return sorted(entries.values(), key=lambda \
+       entry: entry.location if isinstance(entry.location, str) else "")
 
 
 def main():

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -268,8 +268,8 @@ def scan(timeout=DISCOVER_TIMEOUT):
             s.close()
 
     return sorted(
-       entries.values(), key=lambda
-       entry: entry.location if isinstance(entry.location, str) else "")
+        entries.values(), key=lambda
+           entry: entry.location if isinstance(entry.location, str) else "")
 
 
 def main():

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -269,7 +269,7 @@ def scan(timeout=DISCOVER_TIMEOUT):
 
     return sorted(
         entries.values(), key=lambda
-           entry: entry.location if isinstance(entry.location, str) else "")
+            entry: entry.location if isinstance(entry.location, str) else "")
 
 
 def main():


### PR DESCRIPTION
Due to my network setup I seem to have a device that answers strangely. Thus the following error occurs due to a none-string or missing location property.

This pull request fixes the deprecated expectation (from python2 days) that conversion will happen during the call of `sorted`.

> 2017-05-21 19:22:44 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
> Traceback (most recent call last):
>   File "/usr/lib/python3.4/asyncio/tasks.py", line 233, in _step
>     result = coro.throw(exc)
>   File "/srv/homeassistant/lib/python3.4/site-packages/homeassistant/components/discovery.py", line 119, in scan_devices
>     None, _discover, netdisco)
>   File "/usr/lib/python3.4/asyncio/futures.py", line 388, in __iter__
>     yield self  # This tells Task to wait for completion.
>   File "/usr/lib/python3.4/asyncio/tasks.py", line 286, in _wakeup
>     value = future.result()
>   File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
>     raise self._exception
>   File "/usr/lib/python3.4/concurrent/futures/thread.py", line 54, in run
>     result = self.fn(*self.args, **self.kwargs)
>   File "/srv/homeassistant/lib/python3.4/site-packages/homeassistant/components/discovery.py", line 145, in _discover
>     netdisco.scan()
>   File "/home/homeassistant/.homeassistant/deps/netdisco/discovery.py", line 57, in scan
>     self.ssdp.scan()
>   File "/home/homeassistant/.homeassistant/deps/netdisco/ssdp.py", line 38, in scan
>     self.update()
>   File "/home/homeassistant/.homeassistant/deps/netdisco/ssdp.py", line 86, in update
>     entry for entry in scan()
>   File "/home/homeassistant/.homeassistant/deps/netdisco/ssdp.py", line 270, in scan
>     return sorted(entries.values(), key=lambda entry: entry.location)
> TypeError: unorderable types: NoneType() < str()