### PR TITLE
Add Bluetooth + Playstation 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin
 lib
 pip-selfcheck.json
 .tox
+.cache

--- a/netdisco/bluetoothdevices.py
+++ b/netdisco/bluetoothdevices.py
@@ -1,0 +1,27 @@
+"""Add support for discovering Bluetooth devices."""
+import threading
+import bluefang
+
+
+class Bluetooth(object):
+    """Add support for discovering Bluetooth devices."""
+
+    def __init__(self):
+        """Initialize discovery."""
+        self.entries = []
+        self._lock = threading.RLock()
+
+    def scan(self):
+        """Scan network for Bluetooth devices."""
+        with self._lock:
+            self.update()
+
+    def all(self):
+        """Scan and return all found entries."""
+        self.scan()
+        return self.entries
+
+    def update(self):
+        """Scan network for Bluetooth devices."""
+        bluetooth = bluefang.Bluefang()
+        self.entries = bluetooth.scan(timeout_in_ms=10000)

--- a/netdisco/discoverables/playstation.py
+++ b/netdisco/discoverables/playstation.py
@@ -1,0 +1,20 @@
+"""Discover devices."""
+from . import BaseDiscoverable
+
+PLAYSTATION3_BLUETOOTH_CLASS = '2883848'
+
+
+class Discoverable(BaseDiscoverable):
+    """Add support for discovering a device."""
+
+    def __init__(self, netdis):
+        """Initialize discovery."""
+        self._netdis = netdis
+
+    def get_entries(self):
+        """Get all details."""
+        # Could also use class: 0x2c0108
+        # (props.Get("org.bluez.Device1", "Class"))
+        ps3s = [entry for entry in self._netdis.bluetooth.entries
+                if entry.bluetooth_class == PLAYSTATION3_BLUETOOTH_CLASS]
+        return ps3s

--- a/netdisco/discovery.py
+++ b/netdisco/discovery.py
@@ -9,6 +9,7 @@ from .gdm import GDM
 from .lms import LMS
 from .tellstick import Tellstick
 from .daikin import Daikin
+from .bluetoothdevices import Bluetooth
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ class NetworkDiscovery(object):
     GDM scans in the foreground.
     LMS scans in the foreground.
     Tellstick scans in the foreground
+    Bluetooth scans in a background thread.
 
     start: is ready to scan
     scan: scan the network
@@ -38,6 +40,7 @@ class NetworkDiscovery(object):
         self.lms = None
         self.tellstick = None
         self.daikin = None
+        self.bluetooth = None
 
         self.is_discovering = False
         self.discoverables = None
@@ -67,6 +70,10 @@ class NetworkDiscovery(object):
 
         self.daikin = Daikin()
         self.daikin.scan()
+
+        print('Scanning bluetooth')
+        self.bluetooth = Bluetooth()
+        self.bluetooth.scan()
 
     def stop(self):
         """Turn discovery off."""
@@ -136,3 +143,6 @@ class NetworkDiscovery(object):
         print("")
         print("Tellstick")
         pprint(self.tellstick.entries)
+        print("")
+        print("Bluetooth")
+        pprint(self.bluetooth.entries)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 zeroconf==0.19
 requests>=2.0
+bluefang==0.1.5
 # For now we depend on netifaces via zeroconf
 # netifaces

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='netdisco',
-      version='1.0.1',
+      version='1.0.2',
       description='Discover devices on your local network',
       url='https://github.com/home-assistant/netdisco',
       author='Paulus Schoutsen',


### PR DESCRIPTION
Adds support for Bluetooth HID devices, as well as an initial implementation of a Bluetooth-enabled device (PS3).  The [underlying Bluetooth library](https://github.com/tmcneal/bluefang) uses Linux's BlueZ bluetooth stack, so currently only Linux is supported.  This functionality works by registering the host as a Bluetooth Device.  Upon successfully pairing the host with the Playstation 3, Home Assistant will be able to connect to and control the PS3 via the use of HID commands.

This should also allow other Bluetooth HID-compatible systems (other gaming consoles, Blu-Ray players, Apple TV, etc) to be accessible via Home Assistant with code that's very similar to the Playstation 3 implementation.

I have upcoming PRs for Home Assistant and Home Assistant JS that add Playstation as a component, and adds navigation support to the Home Assistant UI that adds up/down/left/right/enter/cancel buttons.