### PR TITLE
Use requirements.txt in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(name='netdisco',
       author='Paulus Schoutsen',
       author_email='Paulus@PaulusSchoutsen.nl',
       license='Apache License 2.0',
-      install_requires=['requests>=2.0', 'zeroconf==0.19'],
+      install_requires=list(val.strip() for val in open('requirements.txt')),
       packages=find_packages(exclude=['tests', 'tests.*']),
       zip_safe=False)


### PR DESCRIPTION
`1.1.0` pulls in zeroconf 0.19.0 despite what the release notes says.