### PR TITLE
Add Lutron Caseta discovery

### DIFF
--- a/netdisco/discoverables/lutron.py
+++ b/netdisco/discoverables/lutron.py
@@ -1,0 +1,12 @@
+"""Discover Lutron Caseta Smart Bridge and Smart Bridge Pro devices."""
+from . import MDNSDiscoverable
+
+
+# pylint: disable=too-few-public-methods
+class Discoverable(MDNSDiscoverable):
+    """Add support for discovering Lutron Caseta Smart Bridge
+    and Smart Bridge Pro devices."""
+
+    def __init__(self, nd):
+        """Initialize the Lutron Smart Bridge discovery."""
+        super(Discoverable, self).__init__(nd, '_lutron._tcp.local.')


### PR DESCRIPTION
Adding support for Lutron Caseta Smart Bridge and Smart Bridge Pro, which support mDNS for discovery.

Here is sample output from netdisco:
```
lutron:
[{'host': '192.168.2.11',
  'hostname': 'Lutron-a0f6fdXXXXXX.local.',
  'port': 22,
  'properties': {'CODEVER': '04.03.05f000',
                 'DEVCLASS': '08050100',
                 'FW_STATUS': '1:NoUpdate',
                 'MACADDR': 'a0:f6:fd:XX:XX:XX',
                 'NW_STATUS': '11:InternetWorking',
                 'ST_STATUS': 'good'}}]
```
Lutron may also be using mDNS for the Lutron Connect Bridge (CONNECT-BDG2) for RadioRA 2 and/or the Staples Connect hub, but I only have the Smart Bridge Pro 2 for testing. When discovery is implemented in Home Assistant for Lutron Caseta, it should check the **DEVCLASS** property for a compatible device.

For reference purposes, here is a table of the DEVCLASS values for Lutron Caseta devices that should be supported by the [Caseta component](https://home-assistant.io/components/lutron_caseta/) in HA:

Device | Model | DEVCLASS
------ | ----- | --------
Smart Bridge | L-BDG-WH | 08040000
Smart Bridge 2 | L-BDG2-WH | 08040100
Smart Bridge Pro | L-BDGPRO-WH | 08050000
Smart Bridge Pro 2 | L-BDGPRO2-WH | 08050100

