### PR TITLE
Ignore non-utf8 ssdp responses in scan()

### DIFF
--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -253,6 +253,8 @@ def scan(timeout=DISCOVER_TIMEOUT):
             for sock in ready:
                 try:
                     response = sock.recv(1024).decode("utf-8")
+                except UnicodeDecodeError:
+                    continue
                 except socket.error:
                     logging.getLogger(__name__).exception(
                         "Socket error while discovering SSDP devices")

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -252,8 +252,11 @@ def scan(timeout=DISCOVER_TIMEOUT):
 
             for sock in ready:
                 try:
-                    response = sock.recv(1024).decode("utf-8")
+                    data, address = sock.recvfrom(1024)
+                    response = data.decode("utf-8")
                 except UnicodeDecodeError:
+                    logging.getLogger(__name__).debug(
+                        'Ignoring invalid unicode response from %s', address)
                     continue
                 except socket.error:
                     logging.getLogger(__name__).exception(

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -204,7 +204,7 @@ def ssdp_request(ssdp_st, ssdp_mx=SSDP_MX):
         '', '']).encode('utf-8')
 
 
-# pylint: disable=invalid-name,too-many-locals
+# pylint: disable=invalid-name,too-many-locals,too-many-branches
 def scan(timeout=DISCOVER_TIMEOUT):
     """Send a message over the network to discover uPnP devices.
 


### PR DESCRIPTION
A Samsung printer on my LAN appears to return both utf-8 and non utf-8 responses to SSDP queries. The non utf-8 causes ssdp.py scan() method to fail. By ignoring UnicodeDecodeError exceptions, the scan continues and even the printer is discovered because it also sends an utf-8 response.