### PR TITLE
Decrease foreground scan delay for services from 5s to 2s.

### DIFF
--- a/netdisco/daikin.py
+++ b/netdisco/daikin.py
@@ -17,7 +17,7 @@ UDP_SRC_PORT = 30000
 UDP_DST_PORT = 30050
 
 DISCOVERY_ADDRESS = '<broadcast>'
-DISCOVERY_TIMEOUT = timedelta(seconds=5)
+DISCOVERY_TIMEOUT = timedelta(seconds=2)
 
 
 class Daikin(object):

--- a/netdisco/lms.py
+++ b/netdisco/lms.py
@@ -4,7 +4,7 @@ import socket
 from .const import ATTR_HOST, ATTR_PORT
 
 DISCOVERY_PORT = 3483
-DEFAULT_DISCOVERY_TIMEOUT = 5
+DEFAULT_DISCOVERY_TIMEOUT = 2
 
 
 class LMS(object):

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -10,8 +10,10 @@ import requests
 
 from netdisco.util import etree_to_dict, interface_addresses
 
-DISCOVER_TIMEOUT = 5
-SSDP_MX = 3
+DISCOVER_TIMEOUT = 2
+# MX is a suggested random wait time for a device to reply, so should be
+# bound by our discovery timeout.
+SSDP_MX = DISCOVER_TIMEOUT
 SSDP_TARGET = ("239.255.255.250", 1900)
 
 RESPONSE_REGEX = re.compile(r'\n(.*)\: (.*)\r')

--- a/netdisco/tellstick.py
+++ b/netdisco/tellstick.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 DISCOVERY_PORT = 30303
 DISCOVERY_ADDRESS = '<broadcast>'
 DISCOVERY_PAYLOAD = b"D"
-DISCOVERY_TIMEOUT = timedelta(seconds=5)
+DISCOVERY_TIMEOUT = timedelta(seconds=2)
 
 
 class Tellstick(object):


### PR DESCRIPTION
A number of services (SSDP, Daikin, etc.) use foreground scan approach,
which means scans are sequential and there times add up, leading to a
long discovery cycle.

This negatively affects user experience of project using NetDisco, e.g.
HomeAssistant. With the original 5s timeout, it takes ~30s for devices
to be discovered after HA startup. As initial acquaintance/setup requies
regular restarts, such delay lead to persistent subjective impression
that HA "is slow". With this patch applied, HA discovery time is decreased
to ~15s, some of which is also masked by web interface reconnect delay,
so overall subjective UX improves considerably, allowing to use HA
in auto-dicovery mode, without need to manually add devices to config
(especially with the recently added Customization Editor UI).