### PR TITLE
detect yeelight's ceiling lamp

### DIFF
--- a/netdisco/discoverables/yeelight.py
+++ b/netdisco/discoverables/yeelight.py
@@ -23,6 +23,8 @@ class Discoverable(MDNSDiscoverable):
             device_type = "white"
         elif entry.name.startswith("yeelink-light-strip1_"):
             device_type = "strip"
+        elif entry.name.startswith("yeelink-light-ceil1_"):
+            device_type = "ceil"
         else:
             logging.warning("Unknown miio device found: %s", entry)
 


### PR DESCRIPTION
Most likely mDNS name for the ceiling lamp (https://www.yeelight.com/en_US/product/luna). See https://github.com/home-assistant/home-assistant/issues/7793 and https://github.com/home-assistant/home-assistant/pull/9741