### PR TITLE
Allow detecting deCONZ separately from Philips Hue bridges

### DIFF
--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -21,6 +21,7 @@ APPLE_TV = "apple_tv"
 HARMONY = "harmony"
 BLUESOUND = "bluesound"
 ZIGGO_MEDIABOX_XL = "ziggo_mediabox_xl"
+DECONZ="deconz"
 
 ATTR_NAME = 'name'
 ATTR_HOST = 'host'

--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -21,7 +21,7 @@ APPLE_TV = "apple_tv"
 HARMONY = "harmony"
 BLUESOUND = "bluesound"
 ZIGGO_MEDIABOX_XL = "ziggo_mediabox_xl"
-DECONZ="deconz"
+DECONZ = "deconz"
 
 ATTR_NAME = 'name'
 ATTR_HOST = 'host'

--- a/netdisco/discoverables/deconz.py
+++ b/netdisco/discoverables/deconz.py
@@ -8,6 +8,6 @@ class Discoverable(SSDPDiscoverable):
     def get_entries(self):
         """Get all the deCONZ uPnP entries."""
         return self.find_by_device_description({
-			"manufacturerURL": "http://www.dresden-elektronik.de",
+            "manufacturerURL": "http://www.dresden-elektronik.de",
             "modelDescription": "dresden elektronik Wireless Light Control"
         })

--- a/netdisco/discoverables/deconz.py
+++ b/netdisco/discoverables/deconz.py
@@ -1,0 +1,13 @@
+"""Discover deCONZ gateways."""
+from . import SSDPDiscoverable
+
+
+class Discoverable(SSDPDiscoverable):
+    """Add support for discovering deCONZ Wireless Light Control gateways."""
+
+    def get_entries(self):
+        """Get all the deCONZ uPnP entries."""
+        return self.find_by_device_description({
+			"manufacturerURL": "http://www.dresden-elektronik.de",
+            "modelDescription": "dresden elektronik Wireless Light Control"
+        })

--- a/netdisco/discoverables/philips_hue.py
+++ b/netdisco/discoverables/philips_hue.py
@@ -9,5 +9,6 @@ class Discoverable(SSDPDiscoverable):
         """Get all the Hue bridge uPnP entries."""
         return self.find_by_device_description({
             "manufacturer": "Royal Philips Electronics",
+			"manufacturerURL": "http://www.philips.com",
             "modelNumber": ["929000226503", "BSB002"]
         })

--- a/netdisco/discoverables/philips_hue.py
+++ b/netdisco/discoverables/philips_hue.py
@@ -9,6 +9,6 @@ class Discoverable(SSDPDiscoverable):
         """Get all the Hue bridge uPnP entries."""
         return self.find_by_device_description({
             "manufacturer": "Royal Philips Electronics",
-			"manufacturerURL": "http://www.philips.com",
+            "manufacturerURL": "http://www.philips.com",
             "modelNumber": ["929000226503", "BSB002"]
         })


### PR DESCRIPTION
This will allow auto-discovery for the new deconz component that is currently being developed at home-assistant/home-assistant#10321.

This also requires changing the Hue detection as deCONZ tries to emulate a Hue bridge.
This gist shows the differences in SSDP replies of deCONZ and a real Hue bridge: https://gist.github.com/kroimon/97c82ace08fa9787cd9e52acfba8486b
