### PR TITLE
Add Nanoleaf Aurora support

### DIFF
--- a/netdisco/discoverables/nanoleaf_aurora.py
+++ b/netdisco/discoverables/nanoleaf_aurora.py
@@ -1,0 +1,10 @@
+"""Discover Nanoleaf Aurora devices."""
+from . import MDNSDiscoverable
+
+
+# pylint: disable=too-few-public-methods
+class Discoverable(MDNSDiscoverable):
+    """Add support for discovering Nanoleaf Aurora devices."""
+
+    def __init__(self, nd):
+        super(Discoverable, self).__init__(nd, '_nanoleafapi._tcp.local.')


### PR DESCRIPTION
Adds mDNS discovery for Nanoleaf Aurora lighting controllers.