### PR TITLE
HTTP header parsing fix for SSDP

### DIFF
--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -16,7 +16,7 @@ DISCOVER_TIMEOUT = 2
 SSDP_MX = DISCOVER_TIMEOUT
 SSDP_TARGET = ("239.255.255.250", 1900)
 
-RESPONSE_REGEX = re.compile(r'\n(.*)\: (.*)\r')
+RESPONSE_REGEX = re.compile(r'\n(.*?)\: *(.*)\r')
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=59)
 


### PR DESCRIPTION
Fixed regular expression for parsing HTTP headers in order to allow 0 or more white spaces between the first colon(:) and field-content.