### PR TITLE
Add support for discovery of TiVo devices providing remote control.

### DIFF
--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -23,6 +23,7 @@ HARMONY = "harmony"
 BLUESOUND = "bluesound"
 ZIGGO_MEDIABOX_XL = "ziggo_mediabox_xl"
 DECONZ = "deconz"
+TIVO_DVR = "tivo_dvr"
 
 ATTR_NAME = 'name'
 ATTR_HOST = 'host'

--- a/netdisco/discoverables/tivo_dvr.py
+++ b/netdisco/discoverables/tivo_dvr.py
@@ -1,0 +1,15 @@
+"""Discover TiVo DVR devices providing the TCP Remote Protocol."""
+from . import MDNSDiscoverable
+
+
+# pylint: disable=too-few-public-methods
+class Discoverable(MDNSDiscoverable):
+    """Add support for discovering TiVo Remote Protocol service."""
+
+    def __init__(self, nd):
+        """Initialize the discovery.
+
+        Yields a dictionary with hostname, host and port along with a
+        properties sub-dictionary with some device specific ids.
+        """
+        super(Discoverable, self).__init__(nd, '_tivo-remote._tcp.local.')


### PR DESCRIPTION
TiVo devices expose a TCP port that allows remote control codes to be sent via the network.
This port is discoverable on MDNS as _tivo-remote._tcp.

Signed-off-by: Pat Thoyts <patthoyts@users.sourceforge.net>