### PR TITLE
Accept upper-case, snake-case and camel-case module names.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,3 +1,7 @@
+[BASIC]
+module-naming-style=snake_case
+module-rgx=(([a-z_][a-z0-9_]*)|(?:DLNA))$
+
 [MASTER]
 reports=no
 


### PR DESCRIPTION
The DLNA module requires a pylint module name exception
as it does not adhere to the snake-case convention.

This might be excessive and possibly the project would prefer a specific
exception for DLNA while maintaining the snake-case convention for all
future modules. This regex will allow further upper-case and camel-case
modules to be added. But then DLNA got it so maybe we should just
be using `module-naming-style=any`?