### PR TITLE
Add discovery of Freebox servers

### DIFF
--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -24,6 +24,7 @@ BLUESOUND = "bluesound"
 ZIGGO_MEDIABOX_XL = "ziggo_mediabox_xl"
 DECONZ = "deconz"
 TIVO_DVR = "tivo_dvr"
+FREEBOX = "freebox"
 
 ATTR_NAME = 'name'
 ATTR_HOST = 'host'

--- a/netdisco/discoverables/freebox.py
+++ b/netdisco/discoverables/freebox.py
@@ -1,0 +1,11 @@
+"""Discover Freebox routers."""
+from . import MDNSDiscoverable
+
+
+# pylint: disable=too-few-public-methods
+class Discoverable(MDNSDiscoverable):
+    """Add support for discovering Freebox routers."""
+
+    def __init__(self, nd):
+        """Initialize the Freebox discovery."""
+        super(Discoverable, self).__init__(nd, '_fbx-api._tcp.local.')


### PR DESCRIPTION
I'm in the process of developing a new device tracker platform for Home Assistant, to support Freeboxes (servers/routers provided by the french FAI Free). This PR adds the discovery of Freeboxes through mDNS, using the service specified in the [API documentation](https://dev.freebox.fr/sdk/os/).

I've tested it on my local network, here is an example of the response I got:

```
 freebox:
 [{'host': '192.168.0.254',
   'hostname': 'Freebox-Server.local.',
   'port': 80,
   'properties': {'api_base_url': '/api/',
                  'api_domain': '******.fbxos.fr',
                  'api_version': '5.0',
                  'device_type': 'FreeboxServer1,1',
                  'https_available': '1',
                  'https_port': '****',
                  'uid': '************'}}]
```
