### PR TITLE
Ignore bravia televisions from songpal detection

### DIFF
--- a/netdisco/discoverables/songpal.py
+++ b/netdisco/discoverables/songpal.py
@@ -10,8 +10,20 @@ class Discoverable(SSDPDiscoverable):
 
     def get_entries(self):
         """Get all the Songpal devices."""
-        return self.find_by_st(
+        devs = self.find_by_st(
             "urn:schemas-sony-com:service:ScalarWebAPI:1")
+
+        # At least some Bravia televisions use this API for communication.
+        # Based on some examples they always seem to lack modelNumber,
+        # so we use it here to keep them undiscovered for now.
+        non_bravias = []
+        for dev in devs:
+            if 'device' in dev.description:
+                device = dev.description['device']
+                if 'modelNumber' in device:
+                    non_bravias.append(dev)
+
+        return non_bravias
 
     def info_from_entry(self, entry):
         """Get information for a device.."""


### PR DESCRIPTION
It was discovered that sony bravia televisions do also use the very same
protocol for communication as "songpal" component, causing them to be added
to homeassistant although all relevant parts for them are not yet supported.

This patch adds an ignore for those devices for the time being,
at some later point the python-songpal will likely be extended to work
more properly on those devices and this may be removed.

Related to https://github.com/home-assistant/home-assistant/issues/13022