### PR TITLE
mDNS prefix of the Yeelight Smart LED Ceiling Light (Youth edition)

### DIFF
--- a/netdisco/discoverables/yeelight.py
+++ b/netdisco/discoverables/yeelight.py
@@ -27,6 +27,8 @@ class Discoverable(MDNSDiscoverable):
             device_type = "bedside"
         elif entry.name.startswith("yeelink-light-ceiling1_"):
             device_type = "ceiling"
+        elif entry.name.startswith("yeelink-light-ceiling2_"):
+            device_type = "ceiling2"
         else:
             logging.warning("Unknown miio device found: %s", entry)
 


### PR DESCRIPTION
https://community.home-assistant.io/t/yeelight-led-ceiling-light-compatible-with-ha/29509/87