### PR TITLE
Added support for Canon printer

### DIFF
--- a/netdisco/discoverables/canon_printer.py
+++ b/netdisco/discoverables/canon_printer.py
@@ -1,0 +1,13 @@
+"""Discover Canon Printers"""
+from . import SSDPDiscoverable
+
+
+class Discoverable(SSDPDiscoverable):
+    """Support for the discovery of Canon Printers"""
+
+    def get_entries(self):
+        """Get all the Canon Printer uPnP entries."""
+        return self.find_by_device_description({
+            "manufacturer": "CANON INC.",
+            "deviceType": "urn:schemas-cipa-jp:device:DPSPrinter:1"
+        })


### PR DESCRIPTION
Example scan result:

```
2018-03-30 13:13:50.940639 - Found new service: canon_printer {'host': '192.168.1.40', 'port': 80, 'ssdp_description': 'http://192.168.1.40:80/Canon_basic.xml', 'name': 'MX620 series (UPnP)_4767DBFBCDEF', 'model_name': 'MX620 series', 'model_number': 'MX620 series', 'serial': 'D8492FFBCDEF', 'manufacturer': 'CANON INC.', 'udn': 'uuid:00000000-0000-1000-8000-D8492FFBCDEF'}
```