### PR TITLE
Add Brother printers support

### DIFF
--- a/netdisco/discoverables/brother_printer.py
+++ b/netdisco/discoverables/brother_printer.py
@@ -1,0 +1,13 @@
+"""Discover Brother printers"""
+from . import MDNSDiscoverable
+
+
+class Discoverable(MDNSDiscoverable):
+    """Support for discovery Brother printers"""
+
+    def __init__(self, nd):
+        """Initialize Brother printers discovery"""
+        super(Discoverable, self).__init__(nd, '_printer._tcp.local.')
+
+    def get_entries(self):
+        return self.find_by_device_name('Brother')


### PR DESCRIPTION
I'm working on a Brother printers component for HA.

Example scan resault:
```
brother_printer:
[{'host': '192.168.10.198',
  'hostname': 'brother.local.',
  'port': 515,
  'properties': {'Binary': 'T',
                 'Color': 'F',
                 'Copies': 'T',
                 'Duplex': 'T',
                 'Fax': 'F',
                 'PaperCustom': 'T',
                 'Scan': 'F',
                 'TBCP': 'F',
                 'Transparent': 'T',
                 'UUID': 'e3248000-80ce-11db-8000-a86bad33c09d',
                 'adminurl': 'http://brother.local./',
                 'note': False,
                 'pdl': 'application/octet-stream,image/urf,image/pwg-raster',
                 'priority': '50',
                 'product': '(Brother HL-L2340D series)',
                 'qtotal': '1',
                 'rp': 'duerqxesz5090',
                 'txtvers': '1',
                 'ty': 'Brother HL-L2340D series',
                 'usb_CMD': 'PJL,HBP,URF',
                 'usb_MDL': 'HL-L2340D series',
                 'usb_MFG': 'Brother'}}]
```