### PR TITLE
Extraction of the yeelight device type fixed

### DIFF
--- a/netdisco/discoverables/yeelight.py
+++ b/netdisco/discoverables/yeelight.py
@@ -19,7 +19,7 @@ class Discoverable(MDNSDiscoverable):
 
         # Example name: yeelink-light-ceiling4_mibt72799069._miio._udp.local.
         info[ATTR_DEVICE_TYPE] = \
-            entry.name.replace(DEVICE_NAME_PREFIX, '').rsplit('_', 1)[0]
+            entry.name.replace(DEVICE_NAME_PREFIX, '').split('_', 1)[0]
 
         return info
 


### PR DESCRIPTION

```
>>> "yeelink-light-ceiling4_mibt72799069._miio._udp.local.".replace('yeelink-light-', '').rsplit('_', 1)[0]
'ceiling4_mibt72799069._miio.'
>>> "yeelink-light-ceiling4_mibt72799069._miio._udp.local.".replace('yeelink-light-', '').split('_', 1)[0]
'ceiling4'
>>> 
```