### PR TITLE
RFC: Introduce yeelight discovery by SSDP on a non standard port (1982)

### DIFF
--- a/netdisco/discoverables/__init__.py
+++ b/netdisco/discoverables/__init__.py
@@ -68,6 +68,10 @@ class SSDPDiscoverable(BaseDiscoverable):
         """Find entries by ST (the device identifier)."""
         return self.netdis.ssdp.find_by_st(st)
 
+    def find_by_location(self, location):
+        """Find entries by location."""
+        return self.netdis.ssdp.find_by_location(location)
+
     def find_by_device_description(self, values):
         """Find entries based on values from their description."""
         return self.netdis.ssdp.find_by_device_description(values)

--- a/netdisco/discoverables/yeelight.py
+++ b/netdisco/discoverables/yeelight.py
@@ -1,28 +1,27 @@
-"""Discover Yeelight bulbs, based on Kodi discoverable."""
-from . import MDNSDiscoverable
-from ..const import ATTR_DEVICE_TYPE
+"""Discover Yeelight devices."""
+from . import SSDPDiscoverable
+from ..const import ATTR_DEVICE_TYPE, ATTR_SERIAL
 
-DEVICE_NAME_PREFIX = 'yeelink-light-'
+ATTR_FIRMWARE_VERSION = 'firmware_version'
+ATTR_SUPPORT = 'support'
 
 
 # pylint: disable=too-few-public-methods
-class Discoverable(MDNSDiscoverable):
+class Discoverable(SSDPDiscoverable):
     """Add support for discovering Yeelight."""
 
-    def __init__(self, nd):
-        """Initialize the Yeelight discovery."""
-        super(Discoverable, self).__init__(nd, '_miio._udp.local.')
-
     def info_from_entry(self, entry):
-        """Return most important info from mDNS entries."""
+        """Return most important info from SSDP entries."""
         info = super().info_from_entry(entry)
 
-        # Example name: yeelink-light-ceiling4_mibt72799069._miio._udp.local.
-        info[ATTR_DEVICE_TYPE] = \
-            entry.name.replace(DEVICE_NAME_PREFIX, '').split('_', 1)[0]
+        # The model doesn't align with the mDNS model names (color vs. color1)
+        info[ATTR_DEVICE_TYPE] = entry.model
+        info[ATTR_SERIAL] = entry.id
+        info[ATTR_FIRMWARE_VERSION] = entry.fw_ver
+        info[ATTR_SUPPORT] = entry.support
 
         return info
 
     def get_entries(self):
-        """ Return yeelight devices. """
-        return self.find_by_device_name(DEVICE_NAME_PREFIX)
+        """Get all the Yeelight compliant device SSDP entries."""
+        return self.find_by_location("yeelight://")

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -30,6 +30,7 @@ ST_ROOTDEVICE = "upnp:rootdevice"
 # Required ST of the yeelight SSDP protocol implementation
 ST_YEELIGHT = "wifi_bulb"
 
+
 class SSDP(object):
     """Control the scanning of uPnP devices and services and caches output."""
 
@@ -227,7 +228,7 @@ def scan(timeout=DISCOVER_TIMEOUT):
     https://embeddedinn.wordpress.com/tutorials/upnp-device-architecture/
     """
     ssdp_requests = ssdp_request(ST_ALL), ssdp_request(ST_ROOTDEVICE), \
-                    ssdp_request(ST_YEELIGHT, ssdp_target=SSDP_TARGET_YEELIGHT)
+        ssdp_request(ST_YEELIGHT, ssdp_target=SSDP_TARGET_YEELIGHT)
 
     stop_wait = datetime.now() + timedelta(seconds=timeout)
 


### PR DESCRIPTION
"Different from SSDP protocol, we choose to send multi-cast messages to port 1982 instead of
standard SSDP port 1900. This is to avoid excessive multi-cast messages being received by
both smart LED and 3rd party devices. It's especially important if the 3rd party device is powerconsumption-sensitive (e.g. smart watch powered by battery)."
cp. http://www.yeelight.com/download/Yeelight_Inter-Operation_Spec.pdf, page 4

The code is untested. I just want to know my approach is fine. The present mDNS discovery of the yeelights isn't sufficient to collect important details about the device capabilities.