### PR TITLE
Add support for Arduino-like devices

### DIFF
--- a/netdisco/discoverables/arduino.py
+++ b/netdisco/discoverables/arduino.py
@@ -1,0 +1,10 @@
+"""Discover Arduino devices."""
+from . import MDNSDiscoverable
+
+
+# pylint: disable=too-few-public-methods
+class Discoverable(MDNSDiscoverable):
+    """Add support for discovering Arduino devices."""
+
+    def __init__(self, nd):
+        super(Discoverable, self).__init__(nd, '_arduino._tcp.local.')


### PR DESCRIPTION
Support for network-enabled Arduino devices including ESP8266 and ESP32. Allows the detection of devices which were flashed with `esphomelib`.

```bash
$ python3 -m netdisco
Discovered devices:
arduino:
[{'host': '192.168.0.112',
  'hostname': 'test.local.',
  'port': 3232,
  'properties': {'auth_upload': 'no',
                 'board': 'nodemcu-32s',
                 'ssh_upload': 'no',
                 'tcp_check': 'no'}}]
[...]
```