### PR TITLE
Add Python 3.7 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
+      sudo: true
+      dist: xenial
 cache:
   directories:
     - $HOME/.cache/pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, lint
+envlist = py34, py35, py36, py37, lint
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
There's no Python 3.7 for trusty available, and `sudo: true` is currently required for `dist: xenial` to take effect.