### PR TITLE
Separate DLNA_DMR and DLNA_DMS devices

### DIFF
--- a/netdisco/const.py
+++ b/netdisco/const.py
@@ -1,7 +1,8 @@
 """Constants of services that can be discovered."""
 
 BELKIN_WEMO = "belkin_wemo"
-DLNA = "DLNA"
+DLNA_DMS = "DLNA_DMS"
+DLNA_DMR = "DLNA_DMR"
 GOOGLE_CAST = "google_cast"
 PHILIPS_HUE = "philips_hue"
 PMS = 'plex_mediaserver'

--- a/netdisco/discoverables/DLNA_DMR.py
+++ b/netdisco/discoverables/DLNA_DMR.py
@@ -1,0 +1,12 @@
+"""Discover DLNA services."""
+from . import SSDPDiscoverable
+
+
+class Discoverable(SSDPDiscoverable):
+    """Add support for discovering DLNA services."""
+
+    def get_entries(self):
+        """Get all the DLNA service uPnP entries."""
+        return self.find_by_st("urn:schemas-upnp-org:device:MediaRenderer:1") + \
+            self.find_by_st("urn:schemas-upnp-org:device:MediaRenderer:2") + \
+            self.find_by_st("urn:schemas-upnp-org:device:MediaRenderer:3")

--- a/netdisco/discoverables/DLNA_DMS.py
+++ b/netdisco/discoverables/DLNA_DMS.py
@@ -8,4 +8,6 @@ class Discoverable(SSDPDiscoverable):
     def get_entries(self):
         """Get all the DLNA service uPnP entries."""
         return self.find_by_st("urn:schemas-upnp-org:device:MediaServer:1") + \
-            self.find_by_st("urn:schemas-upnp-org:device:MediaRenderer:1")
+            self.find_by_st("urn:schemas-upnp-org:device:MediaServer:2") + \
+            self.find_by_st("urn:schemas-upnp-org:device:MediaServer:3") + \
+            self.find_by_st("urn:schemas-upnp-org:device:MediaServer:4")


### PR DESCRIPTION
The DLNA standard specifies four device types (see the [Wikipedia page on DLNA](https://en.wikipedia.org/wiki/Digital_Living_Network_Alliance)):

- DMS: Digital Media Server
- DMR: Digital Media Renderer
- DMC: Digital Media Controller
- DMP: Digital Media Player

At this moment netdisco discovers DMS and DMR devices as one, named DLNA.
Currently, Home Assistant is - as far as I know - only interested in DMR devices (as per https://github.com/home-assistant/home-assistant/pull/14749). The component in home-assistant now needs to detect if the device is a DMR device.

If these device types are separated, home-assistant becomes less 'polluted' with checks for proper device types. Also, introducing a DMS component to home-assistant would not work with discovery, as the DLNA_DMR component already 'catches' the DLNA discoveries.

Also, there are 4 DMS and 3 DMR versions. Currently only version 1 of both is discovered. This pull request makes netdisco support the other versions.

Please do inform me before merging (and releasing) this! The DLNA_DMR component in home-assistant + discovery has to be updated as well.