### PR TITLE
Remove broken GDMDiscoverable.info_from_entry

### DIFF
--- a/netdisco/discoverables/__init__.py
+++ b/netdisco/discoverables/__init__.py
@@ -142,13 +142,6 @@ class GDMDiscoverable(BaseDiscoverable):
         """Initialize GDMDiscoverable."""
         self.netdis = netdis
 
-    def info_from_entry(self, entry):
-        """Get most important info, by default the description location."""
-        return {
-            ATTR_HOST: entry.values['location'],
-            ATTR_PORT: entry.values['port'],
-        }
-
     def find_by_content_type(self, value):
         """Find entries based on values from their content_type."""
         return self.netdis.gdm.find_by_content_type(value)


### PR DESCRIPTION
Another thing found while working on typing stuff. I have no way to test this, but while I believe this is correct in principle, it may also not solve the issue entirely it seems to me the dict may not always contain the accessed keys. In particular, is there a `location` key in the first place, or should `Host` be used instead? And isn't the other `Port` instead of `port`?