### PR TITLE
Add UPnP/IGD discoverable

### DIFF
--- a/netdisco/discoverables/igd.py
+++ b/netdisco/discoverables/igd.py
@@ -1,0 +1,14 @@
+"""Discover DLNA services."""
+from . import SSDPDiscoverable
+
+
+class Discoverable(SSDPDiscoverable):
+    """Add support for discovering IGD services."""
+
+    def get_entries(self):
+        """Get all the IGD service uPnP entries."""
+        return \
+            self.find_by_st(
+                "urn:schemas-upnp-org:device:InternetGatewayDevice:1") + \
+            self.find_by_st(
+                "urn:schemas-upnp-org:device:InternetGatewayDevice:2")


### PR DESCRIPTION
Add UPnP/IGD (Internet Gateway Device) support.

Required for https://github.com/home-assistant/home-assistant/pull/16300