### PR TITLE
Remove netifaces lib reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ build
 pyvenv.cfg
 bin
 lib
+lib64
 pip-selfcheck.json
 .tox
+.pytest_cache/

--- a/netdisco/ssdp.py
+++ b/netdisco/ssdp.py
@@ -7,8 +7,9 @@ from datetime import datetime, timedelta
 from xml.etree import ElementTree
 
 import requests
+import zeroconf
 
-from netdisco.util import etree_to_dict, interface_addresses
+from netdisco.util import etree_to_dict
 
 DISCOVER_TIMEOUT = 2
 # MX is a suggested random wait time for a device to reply, so should be
@@ -221,7 +222,7 @@ def scan(timeout=DISCOVER_TIMEOUT):
     stop_wait = datetime.now() + timedelta(seconds=timeout)
 
     sockets = []
-    for addr in interface_addresses():
+    for addr in zeroconf.get_all_addresses():
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 

--- a/netdisco/util.py
+++ b/netdisco/util.py
@@ -1,8 +1,6 @@
 """Util functions used by Netdisco."""
 from collections import defaultdict
 
-import netifaces
-
 
 # Taken from http://stackoverflow.com/a/10077069
 # pylint: disable=invalid-name
@@ -29,15 +27,3 @@ def etree_to_dict(t):
         else:
             d[tag_name] = text
     return d
-
-
-def interface_addresses(family=netifaces.AF_INET):
-    """Return local addresses of any associated network.
-
-    Gathering of addresses which are bound to a local interface that has
-    broadcast (and probably multicast) capability.
-    """
-    return [addr['addr']
-            for i in netifaces.interfaces()
-            for addr in netifaces.ifaddresses(i).get(family) or []
-            if 'broadcast' in addr]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-zeroconf>=0.19.1
+zeroconf>=0.21.0
 requests>=2.0
-# For now we depend on netifaces via zeroconf
-# netifaces

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='netdisco',
       author='Paulus Schoutsen',
       author_email='Paulus@PaulusSchoutsen.nl',
       license='Apache License 2.0',
-      install_requires=['requests>=2.0', 'zeroconf>=0.19.1'],
+      install_requires=['requests>=2.0', 'zeroconf>=0.21.0'],
       python_requires='>=3',
       packages=find_packages(exclude=['tests', 'tests.*']),
       zip_safe=False)


### PR DESCRIPTION
Since 0.21.0, `zeroconf` replaced the usage of `netifaces` by [`ifaddr`](https://github.com/pydron/ifaddr)

Use `zeroconf.interface_addresses` to replace `util.interface_addresses` method. So that we can remove the depends of `netifaces` lib

fixes #214 

Need help to test on real device supports SSDP protocol.