### PR TITLE
Catch potential decode error when decoding for ascii

### DIFF
--- a/netdisco/tellstick.py
+++ b/netdisco/tellstick.py
@@ -1,6 +1,7 @@
 """Tellstick device discovery."""
 import socket
 from datetime import timedelta
+import logging
 
 
 DISCOVERY_PORT = 30303
@@ -47,6 +48,11 @@ class Tellstick:
 
             except socket.timeout:
                 break
+            except UnicodeDecodeError:
+                # Catch invalid responses
+                logging.getLogger(__name__).debug(
+                    'Ignoring invalid unicode response from %s', address)
+                continue
 
             self.entries = entries
 


### PR DESCRIPTION
As 1024 in tellstick is the same port as SSDP (where even utf-8 seems to crash occasionally) this intends to catch a decode error before it blows up netdisco