### PR TITLE
Added support for HF-LPB100 chip based device discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Current methods of scanning:
  - Plex Media Server using Good Day Mate protocol
  - Logitech Media Server discovery protocol
  - Daikin discovery protocol
+ - HF-LPB100 discovery protocol
  - Web OS discovery protocol
 
 It is the library that powers the device discovery within [Home Assistant](https://home-assistant.io/).

--- a/netdisco/discoverables/hf_lpb100.py
+++ b/netdisco/discoverables/hf_lpb100.py
@@ -1,0 +1,14 @@
+"""Discover HF-LPB100 chip based devices."""
+from netdisco.discoverables import BaseDiscoverable
+
+
+class Discoverable(BaseDiscoverable):
+    """HF-LPB100 chip based discoverable."""
+
+    def __init__(self, netdis):
+        """Initialize the HF-LPB100 chip based discovery."""
+        self._netdis = netdis
+
+    def get_entries(self):
+        """Get all the Sunix Controller device details."""
+        return self._netdis.hf_lpb100.entries

--- a/netdisco/discovery.py
+++ b/netdisco/discovery.py
@@ -9,6 +9,7 @@ from .gdm import GDM
 from .lms import LMS
 from .tellstick import Tellstick
 from .daikin import Daikin
+from .hf_lpb100 import HF_LPB100
 from .smartglass import XboxSmartGlass
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,6 +41,7 @@ class NetworkDiscovery:
         self.lms = None
         self.tellstick = None
         self.daikin = None
+        self.hf_lpb100 = None
         self.xbox_smartglass = None
 
         self.is_discovering = False
@@ -71,6 +73,9 @@ class NetworkDiscovery:
         self.daikin = Daikin()
         self.daikin.scan()
 
+        self.hf_lpb100 = HF_LPB100()
+        self.hf_lpb100.scan()
+
         self.xbox_smartglass = XboxSmartGlass()
         self.xbox_smartglass.scan()
 
@@ -87,6 +92,7 @@ class NetworkDiscovery:
         self.lms = None
         self.tellstick = None
         self.daikin = None
+        self.hf_lpb100 = None
         self.xbox_smartglass = None
         self.discoverables = None
         self.is_discovering = False

--- a/netdisco/hf_lpb100.py
+++ b/netdisco/hf_lpb100.py
@@ -1,0 +1,94 @@
+"""HF-LPB100 chip based device discovery."""
+import socket
+from datetime import timedelta
+
+from netdisco.const import ATTR_HOST, ATTR_SERIAL, ATTR_MODEL_NAME
+
+DISCOVERY_MSG = b'HF-A11ASSISTHREAD'
+
+DISCOVERY_ADDRESS = '<broadcast>'
+DISCOVERY_PORT = 48899
+DISCOVERY_TIMEOUT = timedelta(seconds=2)
+
+
+class HF_LPB100:
+    """Base class to discover HF-LPB100 chip based devices."""
+
+    def __init__(self):
+        """Initialize the HF-LPB100 chip based discovery."""
+        self.entries = []
+
+    def scan(self):
+        """Scan the network."""
+        self.update()
+
+    def all(self):
+        """Scan and return all found entries."""
+        self.scan()
+        return self.entries
+
+    def update(self):
+        """Scan network for HF-LPB100 chip based devices."""
+        entries = []
+
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as cs:
+            cs.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            cs.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            cs.settimeout(DISCOVERY_TIMEOUT.seconds)
+
+            received_messages = []
+
+            try:
+                # send a local broadcast via udp with a "magic packet"
+                cs.sendto(DISCOVERY_MSG, (DISCOVERY_ADDRESS, DISCOVERY_PORT))
+                cs.settimeout(DISCOVERY_TIMEOUT.seconds)
+
+                while True:
+                    data, address = cs.recvfrom(4096)
+                    received_messages.append(data.decode("UTF-8"))
+
+            except socket.timeout:
+                if len(received_messages) <= 0:
+                    return []
+
+        for message in received_messages:
+            try:
+                controller = self._parse_discovery_response(message)
+                if controller is not None:
+                    entries.append(controller)
+            except:
+                print("Error parsing discovery message: %s" % message)
+                return None
+
+        self.entries = entries
+
+    @staticmethod
+    def _parse_discovery_response(message: str) -> {}:
+        # parse received message
+        data = str.split(message, ",")
+
+        # check validity
+        if len(data) == 3:
+            # extract data
+            ip = data[0]
+            hw_id = data[1]
+            model = data[2]
+
+            return {
+                ATTR_HOST: ip,
+                ATTR_SERIAL: hw_id,
+                ATTR_MODEL_NAME: model
+            }
+
+
+def main():
+    """Test HF-LPB100 chip based discovery."""
+    from pprint import pprint
+    hf_lpb100 = HF_LPB100()
+    pprint("Scanning for HF-LPB100 chip based devices..")
+    hf_lpb100.update()
+    pprint(hf_lpb100.entries)
+
+
+if __name__ == "__main__":
+    main()

--- a/netdisco/hf_lpb100.py
+++ b/netdisco/hf_lpb100.py
@@ -56,7 +56,8 @@ class HF_LPB100:
                 controller = self._parse_discovery_response(message)
                 if controller is not None:
                     entries.append(controller)
-            except:
+            # pylint: disable=W0702
+            except:  # noqa: E722
                 print("Error parsing discovery message: %s" % message)
                 return None
 


### PR DESCRIPTION
Hi there,

I am in the process of adding a new component to Home Assistant for the [Sunix LED Strip Controller](https://www.amazon.de/Kontroller-Wireless-LED-Streifen-Fernbedienung-Smartphones/dp/B01J5A7ABW) based on this library: [sunix-ledstrip-controller-client](https://github.com/markusressel/sunix-ledstrip-controller-client).

Since this controller uses the **HF-LPB100 WiFi chip** which supports discovery and I want to make it as easy as possible for Home Assistant users to use this component I want to use the discovery feature to automatically add entities found on the local network to Home Assistant.

**There is a problem though that I am not quite sure on how to tackle:**
The discovery protocol implemented on the HF-LPB100 chip is used by a variety of devices and at least on my LED controller the discovery does **not** include any information on what kind of device this actually is. The data delivered is similar to this:

```
Found new service: hf_lpb100 {'host': '192.168.0.123', 'serial': 'A0BD6667C9A0', 'model_name': 'HF-LPB100-ZJ200'}
```

I am not sure if this response data is always the same on every device using this chip but even if it were I simply cant tell if the device that is detected is an RGBWWCW controller compatible with my library or something totally different. The only way I can think of to "fix" this is by discovering those devices and let the Home Assistant admin/user decide what component implementation should be used for this discovered device after it has been discovered in the frontend. Would this even be possible and desirable?

Thanks for your time,
Markus

PS: The code added in this PR is mostly c&p from the mentioned library (which I own so there is no problem in that) to minimize the impact.