### PR TITLE
Add XLED Twinkly discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Current methods of scanning:
  - Logitech Media Server discovery protocol
  - Daikin discovery protocol
  - Web OS discovery protocol
+ - Twinkly using XLED discovery protocol
 
 It is the library that powers the device discovery within [Home Assistant](https://home-assistant.io/).
 

--- a/netdisco/discoverables/twinkly.py
+++ b/netdisco/discoverables/twinkly.py
@@ -1,0 +1,14 @@
+"""Discover Twinkly devices."""
+from . import BaseDiscoverable
+
+
+class Discoverable(BaseDiscoverable):
+    """Add support for discovering a Twinkly device."""
+
+    def __init__(self, netdis):
+        """Initialize the Twinkly discovery."""
+        self._netdis = netdis
+
+    def get_entries(self):
+        """Get all the twinkly details."""
+        return self._netdis.xled.entries

--- a/netdisco/discovery.py
+++ b/netdisco/discovery.py
@@ -10,6 +10,7 @@ from .lms import LMS
 from .tellstick import Tellstick
 from .daikin import Daikin
 from .smartglass import XboxSmartGlass
+from .xled import XLED
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,6 +24,7 @@ class NetworkDiscovery:
     LMS scans in the foreground.
     Tellstick scans in the foreground
     Xbox One scans in the foreground
+    XLED scans in the foreground
 
     start: is ready to scan
     scan: scan the network
@@ -41,6 +43,7 @@ class NetworkDiscovery:
         self.tellstick = None
         self.daikin = None
         self.xbox_smartglass = None
+        self.xled = None
 
         self.is_discovering = False
         self.discoverables = None
@@ -74,6 +77,9 @@ class NetworkDiscovery:
         self.xbox_smartglass = XboxSmartGlass()
         self.xbox_smartglass.scan()
 
+        self.xled = XLED()
+        self.xled.scan()
+
     def stop(self):
         """Turn discovery off."""
         if not self.is_discovering:
@@ -88,6 +94,7 @@ class NetworkDiscovery:
         self.tellstick = None
         self.daikin = None
         self.xbox_smartglass = None
+        self.xled = None
         self.discoverables = None
         self.is_discovering = False
 
@@ -146,3 +153,6 @@ class NetworkDiscovery:
         print("")
         print("Xbox SmartGlass")
         pprint(self.xbox_smartglass.entries)
+        print("")
+        print("XLED")
+        pprint(self.xled.entries)

--- a/netdisco/xled.py
+++ b/netdisco/xled.py
@@ -1,0 +1,109 @@
+"""XLED Twinkly device discovery."""
+import ipaddress
+import socket
+from datetime import timedelta
+
+from .const import ATTR_HOST, ATTR_NAME
+
+
+DISCOVERY_PORT = 5555
+DISCOVERY_ADDRESS_BCAST = '<broadcast>'
+DISCOVERY_REQUEST = b'\x01discover'
+DISCOVERY_TIMEOUT = timedelta(seconds=2)
+
+
+class XLED:
+    """Base class to discover XLED Twinkly devices."""
+
+    def __init__(self):
+        """Initialize the XLED discovery."""
+        self.entries = []
+        self.last_scan = None
+
+    @staticmethod
+    def parse_discovery_response(data):
+        """Parse discovery response."""
+
+        # First four bytes in reversed order
+        ip_address_data = data[3::-1]
+        ip_address_data = bytes(ip_address_data)
+
+        ip_address_obj = ipaddress.ip_address(ip_address_data)
+        ip_address_exploded = ip_address_obj.exploded
+        if not isinstance(ip_address_exploded, bytes):
+            ip_address_exploded = bytes(ip_address_exploded, 'utf-8')
+
+        device_name = data[6:-1]
+        device_name = bytes(device_name)
+
+        return {ATTR_NAME: device_name.decode('utf-8')}
+
+    def scan(self):
+        """Scan the network for Twinkly devices."""
+        self.update()
+
+    def all(self):
+        """Scan and return all found entries."""
+        self.scan()
+        return self.entries
+
+    @staticmethod
+    def verify_packet(data):
+        """Parse packet if it has correct magic"""
+        if len(data) < 7:
+            return None
+
+        if data[4:6] != b'OK':
+            return None
+
+        if data[-1] != 0:
+            return None
+
+        return XLED.parse_discovery_response(data)
+
+    def update(self):
+        """Scan network for XLED Twinkly devices."""
+        entries = []
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM,
+                             socket.IPPROTO_UDP)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.settimeout(DISCOVERY_TIMEOUT.seconds)
+
+        sock.sendto(DISCOVERY_REQUEST, 0, (DISCOVERY_ADDRESS_BCAST,
+                                           DISCOVERY_PORT))
+
+        while True:
+            try:
+                data, (address, _) = sock.recvfrom(1024)
+
+                response = self.verify_packet(data)
+                if response:
+                    if response == DISCOVERY_REQUEST:
+                        continue
+                    entries.append({
+                        ATTR_HOST: address,
+                        ATTR_NAME: response[ATTR_NAME]
+                    })
+
+            except socket.timeout:
+                break
+
+        self.entries = entries
+
+        sock.close()
+
+
+def main():
+    """Test XLED Twinkly discovery."""
+    from pprint import pprint
+
+    xled = XLED()
+
+    pprint("Scanning for XLED devices..")
+    xled.update()
+    pprint(xled.entries)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_xled.py
+++ b/tests/test_xled.py
@@ -1,0 +1,36 @@
+"""The tests for discovering Twinkly devices via XLED protocol."""
+import unittest
+
+from netdisco.xled import XLED
+
+
+class TestTwinkly(unittest.TestCase):
+    """Test the Twinkly Discoverable."""
+
+    def setUp(self):
+        """
+        Setup test class
+        """
+        self.discovery_response = b'\x01\x04\xa8\xc0OKTwinkly_33AAFF\x00'
+
+    def test_verify_response(self):
+        """
+        Test discovery response verification
+        """
+        valid_parse = XLED.verify_packet(self.discovery_response)
+        invalid_length = XLED.verify_packet(b'\x01\x04\xa8\xc0T\x00')
+        invalid_magic = XLED.verify_packet(
+            b'\x01\x04\xa8\xc0KOTwinkly_33AAFF\x00'
+        )
+
+        self.assertIsNotNone(valid_parse)
+        self.assertIsNone(invalid_length)
+        self.assertIsNone(invalid_magic)
+
+    def test_parse_response(self):
+        """
+        Test discovery response parsing
+        """
+        response = XLED.parse_discovery_response(self.discovery_response)
+
+        self.assertEqual(response['name'], 'Twinkly_33AAFF')


### PR DESCRIPTION
Add support for new discovery method - XLED and LEDWORKS [Twinkly](https://twinkly.com) discoverable.

Pull requests to add new platform under light component of Home Assistant and documentation to home-assistant.io will follow.

For more information see [documentation of Twinkly protocol](https://xled-docs.readthedocs.io/en/latest/). There is also [python library and command line interface](https://xled.readthedocs.io/en/latest/).