### PR TITLE
Discover openhome devices with Product:3 service

### DIFF
--- a/netdisco/discoverables/openhome.py
+++ b/netdisco/discoverables/openhome.py
@@ -7,4 +7,5 @@ class Discoverable(SSDPDiscoverable):
 
     def get_entries(self):
         """Get all the Openhome compliant device uPnP entries."""
-        return self.find_by_st("urn:av-openhome-org:service:Product:2")
+        return self.find_by_st("urn:av-openhome-org:service:Product:2") + \
+            self.find_by_st("urn:av-openhome-org:service:Product:3")


### PR DESCRIPTION
Linn have changed the revision of the `Product` service used for device discovery of `openhome` devices in their latest firmware (http://docs.linn.co.uk/wiki/index.php/Beta:DsDavaar67:Release_Notes) without indicating that in their release notes. 

As a result Home Assistant will not be able to discover or control Linn devices running this version of the firmware.

This adds support for 'Davaar' versions advertising a `urn:av-openhome-org:service:Product:3` service.