### PR TITLE
Add support for Sercomm IP camera discovery.

### DIFF
--- a/netdisco/discoverables/sercomm.py
+++ b/netdisco/discoverables/sercomm.py
@@ -1,0 +1,15 @@
+"""
+Discover Sercomm network cameras.
+These are rebranded as iControl and many others, and are usually
+distributed as part of an ADT or Comcast/Xfinity monitoring package.
+https://github.com/edent/Sercomm-API
+"""
+from . import SSDPDiscoverable
+
+
+class Discoverable(SSDPDiscoverable):
+    """Add support for discovering camera services."""
+
+    def get_entries(self):
+        """Get all Sercomm iControl devices."""
+        return self.find_by_device_description({'manufacturer': 'iControl'})


### PR DESCRIPTION
Sercomm manufactures a line of wired and wireless IP video
cameras that are frequently rebranded and distributed as part
of a security package by vendors such as ADT or Comcast/Xfinity.

At this point they have been pretty well reverse-engineered as well
as rooted: https://github.com/edent/Sercomm-API