### PR TITLE
add support for digitalstrom ip servers (dss-ip)

### DIFF
--- a/netdisco/discoverables/digitalstrom.py
+++ b/netdisco/discoverables/digitalstrom.py
@@ -1,0 +1,12 @@
+"""Discover digitalSTROM server IP (dss-ip)  devices."""
+from . import MDNSDiscoverable
+
+
+class Discoverable(MDNSDiscoverable):
+    """Add support for discovering digitalSTROM server IP (dss-ip) devices."""
+
+    def __init__(self, nd):
+        super(Discoverable, self).__init__(nd, '_http._tcp.local.')
+
+    def get_entries(self):
+        return self.find_by_device_name('dss-ip')


### PR DESCRIPTION
[digitalSTROM](https://www.digitalstrom.com/) is a swiss made home control system.
I've built a [custom component](https://github.com/lociii/homeassistant-config/tree/master/homeassistant/custom_components) for it some months ago. Control of my home is really reliable, so I wanted to go the next step and get the component integrated in Home Assistant.

Discovery result:
```
digitalstrom:
[{'host': '10.211.112.12',
  'hostname': 'dss-ip.local.',
  'port': 80,
  'properties': {}}]
```