### PR TITLE
be more strict on songpal filtering

### DIFF
--- a/netdisco/discoverables/songpal.py
+++ b/netdisco/discoverables/songpal.py
@@ -14,12 +14,16 @@ class Discoverable(SSDPDiscoverable):
             "urn:schemas-sony-com:service:ScalarWebAPI:1")
 
         # At least some Bravia televisions use this API for communication.
-        # Based on some examples they always seem to lack modelNumber,
-        # so we use it here to keep them undiscovered for now.
+        # We filter here based on the friendly name and the model number,
+        # which some of the devices lack.
         non_bravias = []
         for dev in devs:
             if 'device' in dev.description:
                 device = dev.description['device']
+                # friendlyname is required per upnp spec, skip bravias.
+                friendly_name = device['friendlyName']
+                if 'bravia' in friendly_name.lower():
+                    continue
                 if 'modelNumber' in device:
                     non_bravias.append(dev)
 

--- a/netdisco/discoverables/songpal.py
+++ b/netdisco/discoverables/songpal.py
@@ -24,8 +24,8 @@ class Discoverable(SSDPDiscoverable):
                 if scalarweb_info:
                     services = scalarweb_info["X_ScalarWebAPI_ServiceList"]
                     service_types = services["X_ScalarWebAPI_ServiceType"]
-                    # Sony Bravias offer appControl service, soundbars do not
-                    if 'appControl' in service_types:
+                    # Sony Bravias offer videoScreen service, soundbars do not
+                    if 'videoScreen' in service_types:
                         continue
 
                 supported.append(dev)


### PR DESCRIPTION
Check for the existence of `videoScreen` service, which should be solely available on televisions.

Fixes https://community.home-assistant.io/t/platform-songpal-not-ready-yet-log-entry-linked-to-braviatv/93586 and potentially other similar misdetection issues.