### PR TITLE
Add support for discovering enigma2 based devices

### DIFF
--- a/netdisco/discoverables/enigma2.py
+++ b/netdisco/discoverables/enigma2.py
@@ -1,0 +1,13 @@
+"""Discover Enigma2 servers."""
+from . import MDNSDiscoverable
+
+
+class Discoverable(MDNSDiscoverable):
+    """Add support for discovering Enigma2 boxes."""
+
+    def __init__(self, nd):
+        """Initialize the Enigma2 discovery."""
+        super(Discoverable, self).__init__(nd, '_e2stream._tcp.local.')
+
+    def get_entries(self):
+        return self.services.values()

--- a/netdisco/discoverables/enigma2.py
+++ b/netdisco/discoverables/enigma2.py
@@ -8,6 +8,3 @@ class Discoverable(MDNSDiscoverable):
     def __init__(self, nd):
         """Initialize the Enigma2 discovery."""
         super(Discoverable, self).__init__(nd, '_e2stream._tcp.local.')
-
-    def get_entries(self):
-        return self.services.values()

--- a/netdisco/lms.py
+++ b/netdisco/lms.py
@@ -51,7 +51,7 @@ class LMS:
                         # And XXXX is the web interface port (ie 9000)
                         port = None
                         # https://github.com/python/typeshed/pull/2696
-                        if data.startswith(b'JSON', 1):
+                        if data.startswith(b'JSON', 1):  # type: ignore
                             length = data[5:6][0]
                             port = int(data[0-length:])
                         entries.append({

--- a/netdisco/lms.py
+++ b/netdisco/lms.py
@@ -51,7 +51,7 @@ class LMS:
                         # And XXXX is the web interface port (ie 9000)
                         port = None
                         # https://github.com/python/typeshed/pull/2696
-                        if data.startswith(b'JSON', 1):  # type: ignore
+                        if data.startswith(b'JSON', 1):
                             length = data[5:6][0]
                             port = int(data[0-length:])
                         entries.append({

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,6 @@ commands =
 
 [testenv:typing]
 deps =
-    mypy>=0.650
+    mypy==0.650
 commands =
     mypy netdisco tests setup.py example_service.py


### PR DESCRIPTION
**Description:**
Adding enigma2 discovery.

Also fixing a type issue which is failing the build the past 2 weeks:

```
typing runtests: commands[0] | mypy netdisco tests setup.py example_service.py
netdisco/lms.py:54: note: unused 'type: ignore' comment
ERROR: InvocationError for command '/home/travis/build/home-assistant/netdisco/.tox/typing/bin/mypy netdisco tests setup.py example_service.py' (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   typing: commands failed
The command "tox" exited with 1.
```

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant):** home-assistant/home-assistant#21271
